### PR TITLE
Updates specs README to link to specific version

### DIFF
--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -27,4 +27,4 @@ number. The version number will be incremented as follows:
 
 ### Short read alignment (vector)
 
-* [Latest version](short-read-alignment-vector.md)
+* [Version 1.1.1](https://github.com/malariagen/pipelines/blob/c7210d93628aaa31f26baa88a92e10322368b78e/docs/specs/short-read-alignment-vector.md)


### PR DESCRIPTION
This PR updates the README file in the docs/specs folder to link through to the specific version of the vector alignment spec document, now that that has been merged.