### PR TITLE
Add inputs and expected outputs for testing the vector short read alignment pipeline

### DIFF
--- a/pipelines/short-read-alignment-vector/fixtures/ag1000g-phase1-minimal/expected_outputs.tsv
+++ b/pipelines/short-read-alignment-vector/fixtures/ag1000g-phase1-minimal/expected_outputs.tsv
@@ -1,0 +1,3 @@
+sample_id	path
+AN0131-C	ftp://ftp.sra.ebi.ac.uk/vol1/ERZ403/ERZ403847/AN0131_C.bam
+AB0252-C	ftp://ftp.sra.ebi.ac.uk/vol1/ERZ403/ERZ403514/AB0252_C.bam

--- a/pipelines/short-read-alignment-vector/fixtures/ag1000g-phase1-minimal/lanelets.tsv
+++ b/pipelines/short-read-alignment-vector/fixtures/ag1000g-phase1-minimal/lanelets.tsv
@@ -1,0 +1,7 @@
+sample_id	read1_path	read2_path
+AN0131-C	ftp://ftp.sra.ebi.ac.uk/vol1/fastq/ERR317/ERR317337/ERR317337_1.fastq.gz	ftp://ftp.sra.ebi.ac.uk/vol1/fastq/ERR317/ERR317337/ERR317337_2.fastq.gz
+AN0131-C	ftp://ftp.sra.ebi.ac.uk/vol1/fastq/ERR340/ERR340933/ERR340933_1.fastq.gz	ftp://ftp.sra.ebi.ac.uk/vol1/fastq/ERR340/ERR340933/ERR340933_2.fastq.gz
+AN0131-C	ftp://ftp.sra.ebi.ac.uk/vol1/fastq/ERR340/ERR340945/ERR340945_1.fastq.gz	ftp://ftp.sra.ebi.ac.uk/vol1/fastq/ERR340/ERR340945/ERR340945_2.fastq.gz
+AB0252-C	ftp://ftp.sra.ebi.ac.uk/vol1/fastq/ERR327/ERR327108/ERR327108_1.fastq.gz	ftp://ftp.sra.ebi.ac.uk/vol1/fastq/ERR327/ERR327108/ERR327108_2.fastq.gz
+AB0252-C	ftp://ftp.sra.ebi.ac.uk/vol1/fastq/ERR338/ERR338386/ERR338386_1.fastq.gz	ftp://ftp.sra.ebi.ac.uk/vol1/fastq/ERR338/ERR338386/ERR338386_2.fastq.gz
+AB0252-C	ftp://ftp.sra.ebi.ac.uk/vol1/fastq/ERR338/ERR338398/ERR338398_1.fastq.gz	ftp://ftp.sra.ebi.ac.uk/vol1/fastq/ERR338/ERR338398/ERR338398_2.fastq.gz


### PR DESCRIPTION
This PR brings in two tab-delimited files to provide links to test inputs and expected outputs for the vector short read alignment pipeline. The files are:

* `pipelines/short-read-alignment-vector/fixtures/ag1000g-phase1-minimal/lanelets.tsv` - this has six lanelets for two samples, including URLs for data on ENA as fastq
* `pipelines/short-read-alignment-vector/fixtures/ag1000g-phase1-minimal/expected_outputs.tsv` - this has links to two analysis-read bam files for the same two samples, produced previously using the previous vr-pipe implementation of the pipeline

Resolves #6.