### PR TITLE
Mosquito short read alignment pipeline - dockerfiles

### DIFF
--- a/dockerfiles/BWA/Dockerfile
+++ b/dockerfiles/BWA/Dockerfile
@@ -1,35 +1,17 @@
-#FROM bashell/alpine-bash:latest
-FROM alpine:latest
+
+FROM ubuntu:bionic-20191029
 
 ARG version=v0.7.17
 
-# make sure the package repository is up to date
-RUN apk update \
- && apk upgrade \
- && apk add bash \
- && rm -rf /var/cache/*/* \
- && echo "" > /root/.ash_history
+#Get GCC
+RUN apt-get update \
+    && apt-get install -y libc6 \
+    zlib1g \
+    build-essential \
+    zlib1g-dev \
+    make \
+    git
 
-# change default shell from ash to bash
-RUN sed -i -e "s/bin\/ash/bin\/bash/" /etc/passwd
-
-ENV LC_ALL=en_US.UTF-8
-
-WORKDIR /root
-
-#Get GCC & git
-RUN apk update \
- && apk upgrade \
- && apk add build-base \
- && apk add gcc \
- && apk add git
-
-#Get required packages
-RUN apk update \
- && apk upgrade \
- && apk add libxml2-dev \
- && apk add gd-dev \
- && apk add gzip
 
 WORKDIR /
 

--- a/dockerfiles/BWA/Dockerfile
+++ b/dockerfiles/BWA/Dockerfile
@@ -1,5 +1,5 @@
-
 FROM ubuntu:bionic-20191029
+# Unable to build <0.7.16 using bashell/alpine-bash:latest or alpine + bash. Until this issue can be resolved moving to ubuntu
 
 ARG version=v0.7.17
 

--- a/dockerfiles/BWA/Dockerfile
+++ b/dockerfiles/BWA/Dockerfile
@@ -1,0 +1,44 @@
+#FROM bashell/alpine-bash:latest
+FROM alpine:latest
+
+ARG version=v0.7.17
+
+# make sure the package repository is up to date
+RUN apk update \
+ && apk upgrade \
+ && apk add bash \
+ && rm -rf /var/cache/*/* \
+ && echo "" > /root/.ash_history
+
+# change default shell from ash to bash
+RUN sed -i -e "s/bin\/ash/bin\/bash/" /etc/passwd
+
+ENV LC_ALL=en_US.UTF-8
+
+WORKDIR /root
+
+#Get GCC & git
+RUN apk update \
+ && apk upgrade \
+ && apk add build-base \
+ && apk add gcc \
+ && apk add git
+
+#Get required packages
+RUN apk update \
+ && apk upgrade \
+ && apk add libxml2-dev \
+ && apk add gd-dev \
+ && apk add gzip
+
+WORKDIR /
+
+RUN git clone https://github.com/lh3/bwa.git
+
+WORKDIR /bwa
+
+RUN git checkout tags/$version
+
+RUN make
+
+ENV PATH=$PATH:/bwa

--- a/dockerfiles/BioBamBam2.0.106/Dockerfile
+++ b/dockerfiles/BioBamBam2.0.106/Dockerfile
@@ -1,4 +1,5 @@
 FROM ubuntu:bionic-20191029
+#Ubuntu builds are provided by repo. Could move to alpine but would need to build ourselves
 
 RUN apt-get update \
  && apt-get install -y \
@@ -9,11 +10,13 @@ RUN apt-get update \
 
 WORKDIR /tmp
 
-#Get biobambam2
-RUN wget https://gitlab.com/german.tischler/biobambam2/uploads/8006c668e1fad2875f1fd2d952a502fb/biobambam2_x86_64-linux-gnu_2.0.106.tar.xz
+ENV file=biobambam2_x86_64-linux-gnu_2.0.106.tar.xz
 
-RUN tar -C /tmp/ -vxJf /tmp/biobambam2_x86_64-linux-gnu_2.0.106.tar.xz \
-&& rm biobambam2_x86_64-linux-gnu_2.0.106.tar.xz
+#Get biobambam2
+RUN wget https://gitlab.com/german.tischler/biobambam2/uploads/8006c668e1fad2875f1fd2d952a502fb/${file}
+
+RUN tar -C /tmp/ -vxJf /tmp/${file} \
+&& rm ${file}
 
 WORKDIR /tmp/biobambam2/x86_64-linux-gnu/2.0.106
 

--- a/dockerfiles/BioBamBam2.0.106/Dockerfile
+++ b/dockerfiles/BioBamBam2.0.106/Dockerfile
@@ -1,0 +1,26 @@
+FROM ubuntu:bionic-20191029
+
+RUN apt-get update \
+ && apt-get install -y \
+ tar \
+ gzip \
+ wget \
+ xz-utils
+
+WORKDIR /tmp
+
+#Get biobambam2
+RUN wget https://gitlab.com/german.tischler/biobambam2/uploads/8006c668e1fad2875f1fd2d952a502fb/biobambam2_x86_64-linux-gnu_2.0.106.tar.xz
+
+RUN tar -C /tmp/ -vxJf /tmp/biobambam2_x86_64-linux-gnu_2.0.106.tar.xz \
+&& rm biobambam2_x86_64-linux-gnu_2.0.106.tar.xz
+
+WORKDIR /tmp/biobambam2/x86_64-linux-gnu/2.0.106
+
+RUN cp -r bin/* /usr/local/bin
+
+RUN cp -r lib/* /usr/local/lib
+
+WORKDIR /
+
+RUN rm -r /tmp/biobambam2

--- a/dockerfiles/BioBamBam2.0.73/Dockerfile
+++ b/dockerfiles/BioBamBam2.0.73/Dockerfile
@@ -1,4 +1,5 @@
 FROM ubuntu:bionic-20191029
+#Ubuntu builds are provided by repo. Could move to alpine but would need to build ourselves
 
 RUN apt-get update \
  && apt-get install -y \
@@ -9,17 +10,15 @@ RUN apt-get update \
 
 WORKDIR /tmp
 
+ENV file=biobambam2-2.0.73-release-20170620145717-x86_64-etch-linux-gnu.tar.gz
+
 #Get biobambam2
-RUN wget https://github.com/gt1/biobambam2/releases/download/2.0.73-release-20170620145717/biobambam2-2.0.73-release-20170620145717-x86_64-etch-linux-gnu.tar.gz
+RUN wget https://github.com/gt1/biobambam2/releases/download/2.0.73-release-20170620145717/${file}
 
-RUN ls
-
-RUN tar -C /tmp/ -xvzf /tmp/biobambam2-2.0.73-release-20170620145717-x86_64-etch-linux-gnu.tar.gz \
-&& rm biobambam2-2.0.73-release-20170620145717-x86_64-etch-linux-gnu.tar.gz
+RUN tar -C /tmp/ -xvzf /tmp/${file} \
+&& rm ${file}
 
 WORKDIR /tmp/biobambam2/2.0.73-release-20170620145717/x86_64-etch-linux-gnu/
-
-RUN ls
 
 RUN cp -r bin/* /usr/local/bin
 

--- a/dockerfiles/BioBamBam2.0.73/Dockerfile
+++ b/dockerfiles/BioBamBam2.0.73/Dockerfile
@@ -1,0 +1,30 @@
+FROM ubuntu:bionic-20191029
+
+RUN apt-get update \
+ && apt-get install -y \
+ tar \
+ gzip \
+ wget \
+ xz-utils
+
+WORKDIR /tmp
+
+#Get biobambam2
+RUN wget https://github.com/gt1/biobambam2/releases/download/2.0.73-release-20170620145717/biobambam2-2.0.73-release-20170620145717-x86_64-etch-linux-gnu.tar.gz
+
+RUN ls
+
+RUN tar -C /tmp/ -xvzf /tmp/biobambam2-2.0.73-release-20170620145717-x86_64-etch-linux-gnu.tar.gz \
+&& rm biobambam2-2.0.73-release-20170620145717-x86_64-etch-linux-gnu.tar.gz
+
+WORKDIR /tmp/biobambam2/2.0.73-release-20170620145717/x86_64-etch-linux-gnu/
+
+RUN ls
+
+RUN cp -r bin/* /usr/local/bin
+
+RUN cp -r lib/* /usr/local/lib
+
+WORKDIR /
+
+RUN rm -r /tmp/biobambam2

--- a/dockerfiles/Picard/Dockerfile
+++ b/dockerfiles/Picard/Dockerfile
@@ -1,18 +1,6 @@
-FROM alpine:latest
+FROM bashell/alpine-bash:latest
 
 ARG version=2.22.3
-
-# make sure the package repository is up to date
-RUN apk update \
- && apk upgrade \
- && apk add bash \
- && rm -rf /var/cache/*/* \
- && echo "" > /root/.ash_history
-
-# change default shell from ash to bash
-RUN sed -i -e "s/bin\/ash/bin\/bash/" /etc/passwd
-
-ENV LC_ALL=en_US.UTF-8
 
 WORKDIR /root
 

--- a/dockerfiles/Picard/Dockerfile
+++ b/dockerfiles/Picard/Dockerfile
@@ -1,4 +1,4 @@
-FROM bashell/alpine-bash:latest
+FROM bashell/alpine-bash@sha256:965a718a07c700a5204c77e391961edee37477634ce2f9cf652a8e4c2db858ff
 
 ARG version=2.22.3
 

--- a/dockerfiles/Picard/Dockerfile
+++ b/dockerfiles/Picard/Dockerfile
@@ -1,0 +1,24 @@
+FROM alpine:latest
+
+ARG version=2.22.3
+
+# make sure the package repository is up to date
+RUN apk update \
+ && apk upgrade \
+ && apk add bash \
+ && rm -rf /var/cache/*/* \
+ && echo "" > /root/.ash_history
+
+# change default shell from ash to bash
+RUN sed -i -e "s/bin\/ash/bin\/bash/" /etc/passwd
+
+ENV LC_ALL=en_US.UTF-8
+
+WORKDIR /root
+
+RUN apk update \
+ && apk upgrade \
+ && apk add openjdk8-jre-base \
+ && apk add wget
+
+RUN wget https://github.com/broadinstitute/picard/releases/download/${version}/picard.jar

--- a/dockerfiles/README.md
+++ b/dockerfiles/README.md
@@ -5,8 +5,6 @@
 Supports the `build-arg` `version` that represents the tag name found in the repo
 https://github.com/lh3/bwa. Default version v0.7.17.
 
-**Currently only builds for v0.7.16 and above**
-
 ### Samtools
 Supports the `build-arg` `version` that represents the tag name found in the repo
 https://github.com/samtools/samtools. Default version 1.9.
@@ -25,7 +23,7 @@ The Broad Institute provided Dockerfile for GATK can be found on [docker hub](hu
 
 ## Mosquito short read alignment pipeline
 
-- bwa 0.7.15 - unsupported
+- bwa 0.7.15 - `docker build . --tag=bwa0.7.15 --build-arg version=v0.7.15`
 - samtools 1.4.1 (htslib 1.4.1) - `docker build . --tag=samtools1.4.1 --build-arg version=1.4.1`
 - picard 2.9.2 - ` docker build . --tag=picard2.9.2 --build-arg version=2.9.2`
 - biobambam 2.0.73 - `docker build . --tag=biobambam2.0.73`

--- a/dockerfiles/README.md
+++ b/dockerfiles/README.md
@@ -2,25 +2,31 @@
 # Dockerfile images
 
 ### BWA
-Supports the `build-arg` `version` that represents the tag name found in the BWA repo
-https://github.com/lh3/bwa. Defaults to v0.7.17.
+Supports the `build-arg` `version` that represents the tag name found in the repo
+https://github.com/lh3/bwa. Default version v0.7.17.
 
 **Currently only builds for v0.7.16 and above**
 
 ### Samtools
-Supports the `build-arg` `version` that represents the tag name found in the BWA repo
-https://github.com/samtools/samtools. Defaults to 1.9.
+Supports the `build-arg` `version` that represents the tag name found in the repo
+https://github.com/samtools/samtools. Default version 1.9.
 
 ### BioBamBam
+Comes in two different flavours v2.0.73 and v2.0.106. New versions are quick to build but can not be automated due to the release methods used for this program.
 
 ### Picard
+Supports the `build-arg` `version` that represents the tag name found in the repo
+https://github.com/broadinstitute/picard. Default version 2.22.3. Executed using `java -jar picard.jar`
 
 ### GATK
+The Broad Institute provided Dockerfile for GATK can be found on [docker hub](hub.docker.com).
+- For GATK 3.X use https://hub.docker.com/r/broadinstitute/gatk3
+- For GATK 4.X use https://hub.docker.com/r/broadinstitute/gatk/
 
 ## Mosquito short read alignment pipeline
 
 - bwa 0.7.15 - unsupported
 - samtools 1.4.1 (htslib 1.4.1) - `docker build . --tag=samtools1.4.1 --build-arg version=1.4.1`
-- picard 2.9.2 - broad tag history dose not go back this far!
-- biobambam 2.0.73
-- GATK 3.7-0
+- picard 2.9.2 - ` docker build . --tag=picard2.9.2 --build-arg version=2.9.2`
+- biobambam 2.0.73 - `docker build . --tag=biobambam2.0.73`
+- GATK 3.7-0 - `docker pull broadinstitute/gatk3:3.7-0`

--- a/dockerfiles/README.md
+++ b/dockerfiles/README.md
@@ -1,0 +1,26 @@
+
+# Dockerfile images
+
+### BWA
+Supports the `build-arg` `version` that represents the tag name found in the BWA repo
+https://github.com/lh3/bwa. Defaults to v0.7.17.
+
+**Currently only builds for v0.7.16 and above**
+
+### Samtools
+Supports the `build-arg` `version` that represents the tag name found in the BWA repo
+https://github.com/samtools/samtools. Defaults to 1.9.
+
+### BioBamBam
+
+### Picard
+
+### GATK
+
+## Mosquito short read alignment pipeline
+
+- bwa 0.7.15 - unsupported
+- samtools 1.4.1 (htslib 1.4.1) - `docker build . --tag=samtools1.4.1 --build-arg version=1.4.1`
+- picard 2.9.2 - broad tag history dose not go back this far!
+- biobambam 2.0.73
+- GATK 3.7-0

--- a/dockerfiles/README.md
+++ b/dockerfiles/README.md
@@ -17,14 +17,14 @@ Supports the `build-arg` `version` that represents the tag name found in the rep
 https://github.com/broadinstitute/picard. Default version 2.22.3. Executed using `java -jar picard.jar`
 
 ### GATK
-The Broad Institute provided Dockerfile for GATK can be found on [docker hub](hub.docker.com).
+The Broad Institute provided Dockerfile for GATK can be found on [docker hub](https://hub.docker.com).
 - For GATK 3.X use https://hub.docker.com/r/broadinstitute/gatk3
 - For GATK 4.X use https://hub.docker.com/r/broadinstitute/gatk/
 
 ## Mosquito short read alignment pipeline
 
-- bwa 0.7.15 - `docker build . --tag=bwa0.7.15 --build-arg version=v0.7.15`
-- samtools 1.4.1 (htslib 1.4.1) - `docker build . --tag=samtools1.4.1 --build-arg version=1.4.1`
-- picard 2.9.2 - ` docker build . --tag=picard2.9.2 --build-arg version=2.9.2`
-- biobambam 2.0.73 - `docker build . --tag=biobambam2.0.73`
+- bwa 0.7.15 - `docker build . --tag=bwa:0.7.15 --build-arg version=v0.7.15`
+- samtools 1.4.1 (htslib 1.4.1) - `docker build . --tag=samtools:1.4.1 --build-arg version=1.4.1`
+- picard 2.9.2 - ` docker build . --tag=picard:2.9.2 --build-arg version=2.9.2`
+- biobambam 2.0.73 - `docker build . --tag=biobambam:2.0.73`
 - GATK 3.7-0 - `docker pull broadinstitute/gatk3:3.7-0`

--- a/dockerfiles/Samtools/Dockerfile
+++ b/dockerfiles/Samtools/Dockerfile
@@ -1,4 +1,4 @@
-FROM bashell/alpine-bash:latest
+FROM bashell/alpine-bash@sha256:965a718a07c700a5204c77e391961edee37477634ce2f9cf652a8e4c2db858ff
 
 ARG version=1.9
 

--- a/dockerfiles/Samtools/Dockerfile
+++ b/dockerfiles/Samtools/Dockerfile
@@ -3,7 +3,6 @@ FROM bashell/alpine-bash:latest
 ARG version=1.9
 
 RUN apk update \
- && apk upgrade \
  && apk add --no-cache \
  build-base \
  zlib-dev \
@@ -31,5 +30,3 @@ RUN apk del build-base zlib-dev ca-certificates wget
 RUN apk update \
  && apk upgrade \
  && apk add --no-cache python3
-
-ENTRYPOINT samtools

--- a/dockerfiles/Samtools/Dockerfile
+++ b/dockerfiles/Samtools/Dockerfile
@@ -1,0 +1,35 @@
+FROM bashell/alpine-bash:latest
+
+ARG version=1.9
+
+RUN apk update \
+ && apk upgrade \
+ && apk add --no-cache \
+ build-base \
+ zlib-dev \
+ bzip2-dev \
+ xz-dev \
+ ncurses-dev \
+ ca-certificates \
+ wget
+
+RUN wget -q https://github.com/samtools/samtools/releases/download/${version}/samtools-${version}.tar.bz2
+
+RUN mkdir /samtools-${version}
+
+RUN tar -C / -xjvf samtools-${version}.tar.bz2
+
+WORKDIR /samtools-${version}/
+
+RUN make
+
+RUN mv /samtools-${version}/samtools /bin/ \
+ && rm -rf /samtools*
+
+RUN apk del build-base zlib-dev ca-certificates wget
+
+RUN apk update \
+ && apk upgrade \
+ && apk add --no-cache python3
+
+ENTRYPOINT samtools


### PR DESCRIPTION
This PR adds a set of dockerfiles for the following programs 
- BWA
- Samtools
- BioBamBam
- Picard

It also contains a `README.md` detailing their usage and how to build the versions needed for the mosquito short read alignment pipeline

Note GATK is provided by the Broad Institute via docker hub.