### PR TITLE
Updated readme and added in fix to picard location to resolve issue #15

### DIFF
--- a/dockerfiles/Picard/Dockerfile
+++ b/dockerfiles/Picard/Dockerfile
@@ -2,11 +2,16 @@ FROM bashell/alpine-bash@sha256:965a718a07c700a5204c77e391961edee37477634ce2f9cf
 
 ARG version=2.22.3
 
-WORKDIR /root
-
 RUN apk update \
  && apk upgrade \
  && apk add openjdk8-jre-base \
  && apk add wget
 
+WORKDIR /picard-${version}/
+
 RUN wget https://github.com/broadinstitute/picard/releases/download/${version}/picard.jar
+
+WORKDIR /
+
+RUN mv /picard-${version}/picard.jar /bin/ \
+ && rm -rf /picard-${version}/

--- a/dockerfiles/README.md
+++ b/dockerfiles/README.md
@@ -14,7 +14,7 @@ Comes in two different flavours v2.0.73 and v2.0.106. New versions are quick to 
 
 ### Picard
 Supports the `build-arg` `version` that represents the tag name found in the repo
-https://github.com/broadinstitute/picard. Default version 2.22.3. Executed using `java -jar picard.jar`
+https://github.com/broadinstitute/picard. Default version 2.22.3. Executed using `java -jar /bin/picard.jar`
 
 ### GATK
 The Broad Institute provided Dockerfile for GATK can be found on [docker hub](https://hub.docker.com).


### PR DESCRIPTION
This PR is to add in the changes made by @gbggrant to resolve the Picard location issue detailed in #15. To save clicking through the issue is as follows 


>Add the changes made to the Picard Dockerfile by @gbggrant to resolve the location issue when using a singularity container.

> Picard was stored by default in /root but because singularity executes with the user's credentials it is impossible to access unless executed as root. The change proposed by @gbggrant is to move the jar from /root to /bin
