### PR TITLE
Added Dockerfile and single-task WDL for baseline amplicon SNP calling parasite pipeline.

### DIFF
--- a/dockerfiles/README.md
+++ b/dockerfiles/README.md
@@ -1,6 +1,11 @@
 
 # Dockerfile images
 
+### amplicon-parasite-tools
+Contains a conda environment with all tools needed for the amplicon SNP-calling (BCL-to-VCF, "Stage1, Steps 1-3") parasite pipeline
+(except for those tools used to process manifest files, see [here](https://gitlab.com/malariagen-aspis/aspis-pipeline/-/blob/e8b35283ad70c41b4d0c9c9a3a660e31fff4431b/Docker/ManifestTools/Dockerfile)).
+Environment file copied from [here](https://gitlab.com/malariagen-aspis/aspis-pipeline/-/blob/e8b35283ad70c41b4d0c9c9a3a660e31fff4431b/Stage1-Pipeline/conda/pipe-tools.txt).
+
 ### BWA
 Supports the `build-arg` `version` that represents the tag name found in the repo
 https://github.com/lh3/bwa. Default version v0.7.17.
@@ -19,7 +24,7 @@ https://github.com/broadinstitute/picard. Default version 2.22.3. Executed using
 ### GATK
 The Broad Institute provided Dockerfile for GATK can be found on [docker hub](https://hub.docker.com).
 - For GATK 3.X use https://hub.docker.com/r/broadinstitute/gatk3
-- For GATK 4.X use https://hub.docker.com/r/broadinstitute/gatk/
+- For GATK 4.X use https://hub.docker.com/r/broadinstitute/gatk
 
 ## Mosquito short read alignment pipeline
 

--- a/dockerfiles/amplicon-parasite-tools/Dockerfile
+++ b/dockerfiles/amplicon-parasite-tools/Dockerfile
@@ -1,0 +1,98 @@
+FROM continuumio/miniconda3:4.8.2
+
+# Create a yml file specifying a conda environment that contains all tools for the amplicon SNP-calling (BCL-to-VCF, "Stage1, Steps 1-3") parasite pipeline
+# (except for those tools used to process manifest files, see https://gitlab.com/malariagen-aspis/aspis-pipeline/-/blob/e8b35283ad70c41b4d0c9c9a3a660e31fff4431b/Docker/ManifestTools/Dockerfile).
+# Copied from https://gitlab.com/malariagen-aspis/aspis-pipeline/-/blob/e8b35283ad70c41b4d0c9c9a3a660e31fff4431b/Stage1-Pipeline/conda/pipe-tools.txt.
+# Could possibly be simplified or updated further.
+# Note that using the Docker images for individual tools (located at https://gitlab.com/malariagen-aspis/aspis-pipeline/-/tree/master/Docker) led to errors from bamcollate2;
+# Similarly, using a conda environment with the latest versions of packages from the https://dnap.cog.sanger.ac.uk/npg/conda/prod/Ubuntu/18.04/ channel does not give a working version of bcftools.
+RUN echo "# This file may be used to create an environment using:" > amplicon-parasite-tools.yml && \
+    echo "# $ conda create --name <env> --file <this file>" >> amplicon-parasite-tools.yml && \
+    echo "# platform: linux-64" >> amplicon-parasite-tools.yml && \
+    echo "@EXPLICIT" >> amplicon-parasite-tools.yml && \
+    echo "https://dnap.cog.sanger.ac.uk/npg/conda/prod/Ubuntu/18.04/linux-64/teepot-1.2.0-1.tar.bz2" >> amplicon-parasite-tools.yml && \
+    echo "https://dnap.cog.sanger.ac.uk/npg/conda/prod/Ubuntu/18.04/linux-64/libbzip2-1.0.6-1.tar.bz2" >> amplicon-parasite-tools.yml && \
+    echo "https://repo.anaconda.com/pkgs/main/linux-64/libgcc-ng-8.2.0-hdf63c60_1.tar.bz2" >> amplicon-parasite-tools.yml && \
+    echo "https://dnap.cog.sanger.ac.uk/npg/conda/prod/Ubuntu/18.04/linux-64/libgcc_npg-7.3.0-0.tar.bz2" >> amplicon-parasite-tools.yml && \
+    echo "https://dnap.cog.sanger.ac.uk/npg/conda/prod/Ubuntu/18.04/linux-64/liblzma-5.2.3-1.tar.bz2" >> amplicon-parasite-tools.yml && \
+    echo "https://repo.anaconda.com/pkgs/main/linux-64/libstdcxx-ng-8.2.0-hdf63c60_1.tar.bz2" >> amplicon-parasite-tools.yml && \
+    echo "https://dnap.cog.sanger.ac.uk/npg/conda/prod/Ubuntu/18.04/linux-64/nettle-3.3-0.tar.bz2" >> amplicon-parasite-tools.yml && \
+    echo "https://dnap.cog.sanger.ac.uk/npg/conda/prod/Ubuntu/18.04/linux-64/openssl-1.0.2o-0.tar.bz2" >> amplicon-parasite-tools.yml && \
+    echo "https://dnap.cog.sanger.ac.uk/npg/conda/prod/Ubuntu/18.04/linux-64/zlib-1.2.11-0.tar.bz2" >> amplicon-parasite-tools.yml && \
+    echo "https://dnap.cog.sanger.ac.uk/npg/conda/prod/Ubuntu/18.04/linux-64/bwa-aligner-0.7.17-0.tar.bz2" >> amplicon-parasite-tools.yml && \
+    echo "https://dnap.cog.sanger.ac.uk/npg/conda/prod/Ubuntu/18.04/linux-64/bzip2-1.0.6-1.tar.bz2" >> amplicon-parasite-tools.yml && \
+    echo "https://dnap.cog.sanger.ac.uk/npg/conda/prod/Ubuntu/18.04/linux-64/gmplib-6.1.2-0.tar.bz2" >> amplicon-parasite-tools.yml && \
+    echo "https://repo.anaconda.com/pkgs/main/linux-64/libffi-3.2.1-hd88cf55_4.tar.bz2" >> amplicon-parasite-tools.yml && \
+    echo "https://repo.anaconda.com/pkgs/main/linux-64/liblief-0.9.0-h7725739_2.tar.bz2" >> amplicon-parasite-tools.yml && \
+    echo "https://dnap.cog.sanger.ac.uk/npg/conda/prod/Ubuntu/18.04/linux-64/libpng-1.6.34-0.tar.bz2" >> amplicon-parasite-tools.yml && \
+    echo "https://dnap.cog.sanger.ac.uk/npg/conda/prod/Ubuntu/18.04/linux-64/libxml2-2.9.7-2.tar.bz2" >> amplicon-parasite-tools.yml && \
+    echo "https://repo.anaconda.com/pkgs/main/linux-64/lz4-c-1.8.1.2-h14c3975_0.tar.bz2" >> amplicon-parasite-tools.yml && \
+    echo "https://repo.anaconda.com/pkgs/main/linux-64/lzo-2.10-h49e0be7_2.tar.bz2" >> amplicon-parasite-tools.yml && \
+    echo "https://repo.anaconda.com/pkgs/main/linux-64/ncurses-6.1-he6710b0_1.tar.bz2" >> amplicon-parasite-tools.yml && \
+    echo "https://repo.anaconda.com/pkgs/main/linux-64/patchelf-0.9-he6710b0_3.tar.bz2" >> amplicon-parasite-tools.yml && \
+    echo "https://repo.anaconda.com/pkgs/main/linux-64/tk-8.6.8-hbc83047_0.tar.bz2" >> amplicon-parasite-tools.yml && \
+    echo "https://dnap.cog.sanger.ac.uk/npg/conda/prod/Ubuntu/18.04/linux-64/xz-5.2.3-1.tar.bz2" >> amplicon-parasite-tools.yml && \
+    echo "https://repo.anaconda.com/pkgs/main/linux-64/yaml-0.1.7-had09818_2.tar.bz2" >> amplicon-parasite-tools.yml && \
+    echo "https://dnap.cog.sanger.ac.uk/npg/conda/prod/Ubuntu/18.04/linux-64/gnutls-3.4.17-0.tar.bz2" >> amplicon-parasite-tools.yml && \
+    echo "https://repo.anaconda.com/pkgs/main/linux-64/libarchive-3.3.2-h4a23435_4.tar.bz2" >> amplicon-parasite-tools.yml && \
+    echo "https://repo.anaconda.com/pkgs/main/linux-64/libedit-3.1.20181209-hc058e9b_0.tar.bz2" >> amplicon-parasite-tools.yml && \
+    echo "https://dnap.cog.sanger.ac.uk/npg/conda/prod/Ubuntu/18.04/linux-64/libgd-2.2.5-0.tar.bz2" >> amplicon-parasite-tools.yml && \
+    echo "https://repo.anaconda.com/pkgs/main/linux-64/readline-7.0-h7b6447c_5.tar.bz2" >> amplicon-parasite-tools.yml && \
+    echo "https://dnap.cog.sanger.ac.uk/npg/conda/prod/Ubuntu/18.04/linux-64/libcurl-7.58.0-1.tar.bz2" >> amplicon-parasite-tools.yml && \
+    echo "https://repo.anaconda.com/pkgs/main/linux-64/sqlite-3.27.2-h7b6447c_0.tar.bz2" >> amplicon-parasite-tools.yml && \
+    echo "https://dnap.cog.sanger.ac.uk/npg/conda/prod/Ubuntu/18.04/linux-64/htslib-1.8-plugins_201712_2.tar.bz2" >> amplicon-parasite-tools.yml && \
+    echo "https://repo.anaconda.com/pkgs/main/linux-64/python-3.6.5-hc3d631a_2.tar.bz2" >> amplicon-parasite-tools.yml && \
+    echo "https://dnap.cog.sanger.ac.uk/npg/conda/prod/Ubuntu/18.04/linux-64/staden_io_lib-1.14.9-4.tar.bz2" >> amplicon-parasite-tools.yml && \
+    echo "https://repo.anaconda.com/pkgs/main/linux-64/asn1crypto-0.24.0-py36_0.tar.bz2" >> amplicon-parasite-tools.yml && \
+    echo "https://dnap.cog.sanger.ac.uk/npg/conda/prod/Ubuntu/18.04/linux-64/bambi-0.11.1-1.tar.bz2" >> amplicon-parasite-tools.yml && \
+    echo "https://dnap.cog.sanger.ac.uk/npg/conda/prod/Ubuntu/18.04/linux-64/bcftools-1.8-0.tar.bz2" >> amplicon-parasite-tools.yml && \
+    echo "https://repo.anaconda.com/pkgs/main/linux-64/certifi-2019.3.9-py36_0.tar.bz2" >> amplicon-parasite-tools.yml && \
+    echo "https://repo.anaconda.com/pkgs/main/linux-64/chardet-3.0.4-py36_1.tar.bz2" >> amplicon-parasite-tools.yml && \
+    echo "https://repo.anaconda.com/pkgs/main/linux-64/cryptography-vectors-2.3.1-py36_0.tar.bz2" >> amplicon-parasite-tools.yml && \
+    echo "https://repo.anaconda.com/pkgs/main/linux-64/filelock-3.0.10-py36_0.tar.bz2" >> amplicon-parasite-tools.yml && \
+    echo "https://repo.anaconda.com/pkgs/main/linux-64/glob2-0.6-py36_1.tar.bz2" >> amplicon-parasite-tools.yml && \
+    echo "https://repo.anaconda.com/pkgs/main/linux-64/idna-2.8-py36_0.tar.bz2" >> amplicon-parasite-tools.yml && \
+    echo "https://dnap.cog.sanger.ac.uk/npg/conda/prod/Ubuntu/18.04/linux-64/libmaus2-2.0.420-0.tar.bz2" >> amplicon-parasite-tools.yml && \
+    echo "https://repo.anaconda.com/pkgs/main/linux-64/markupsafe-1.1.1-py36h7b6447c_0.tar.bz2" >> amplicon-parasite-tools.yml && \
+    echo "https://repo.anaconda.com/pkgs/main/linux-64/pkginfo-1.5.0.1-py36_0.tar.bz2" >> amplicon-parasite-tools.yml && \
+    echo "https://repo.anaconda.com/pkgs/main/linux-64/psutil-5.6.1-py36h7b6447c_0.tar.bz2" >> amplicon-parasite-tools.yml && \
+    echo "https://repo.anaconda.com/pkgs/main/linux-64/py-lief-0.9.0-py36h7725739_2.tar.bz2" >> amplicon-parasite-tools.yml && \
+    echo "https://repo.anaconda.com/pkgs/main/linux-64/pycosat-0.6.3-py36h14c3975_0.tar.bz2" >> amplicon-parasite-tools.yml && \
+    echo "https://repo.anaconda.com/pkgs/main/linux-64/pycparser-2.19-py36_0.tar.bz2" >> amplicon-parasite-tools.yml && \
+    echo "https://repo.anaconda.com/pkgs/main/linux-64/pysocks-1.6.8-py36_0.tar.bz2" >> amplicon-parasite-tools.yml && \
+    echo "https://repo.anaconda.com/pkgs/main/linux-64/python-libarchive-c-2.8-py36_6.tar.bz2" >> amplicon-parasite-tools.yml && \
+    echo "https://repo.anaconda.com/pkgs/main/linux-64/pytz-2018.9-py36_0.tar.bz2" >> amplicon-parasite-tools.yml && \
+    echo "https://repo.anaconda.com/pkgs/main/linux-64/pyyaml-5.1-py36h7b6447c_0.tar.bz2" >> amplicon-parasite-tools.yml && \
+    echo "https://repo.anaconda.com/pkgs/main/linux-64/ruamel_yaml-0.15.46-py36h14c3975_0.tar.bz2" >> amplicon-parasite-tools.yml && \
+    echo "https://dnap.cog.sanger.ac.uk/npg/conda/prod/Ubuntu/18.04/linux-64/samtools-1.8-0.tar.bz2" >> amplicon-parasite-tools.yml && \
+    echo "https://repo.anaconda.com/pkgs/main/linux-64/six-1.12.0-py36_0.tar.bz2" >> amplicon-parasite-tools.yml && \
+    echo "https://repo.anaconda.com/pkgs/main/linux-64/soupsieve-1.8-py36_0.tar.bz2" >> amplicon-parasite-tools.yml && \
+    echo "https://dnap.cog.sanger.ac.uk/npg/conda/prod/Ubuntu/18.04/linux-64/staden_io_bin-1.14.9-4.tar.bz2" >> amplicon-parasite-tools.yml && \
+    echo "https://repo.anaconda.com/pkgs/main/linux-64/tqdm-4.31.1-py36_1.tar.bz2" >> amplicon-parasite-tools.yml && \
+    echo "https://repo.anaconda.com/pkgs/main/linux-64/beautifulsoup4-4.7.1-py36_1.tar.bz2" >> amplicon-parasite-tools.yml && \
+    echo "https://dnap.cog.sanger.ac.uk/npg/conda/prod/Ubuntu/18.04/linux-64/biobambam2-2.0.79-0.tar.bz2" >> amplicon-parasite-tools.yml && \
+    echo "https://repo.anaconda.com/pkgs/main/linux-64/cffi-1.12.2-py36h2e261b9_1.tar.bz2" >> amplicon-parasite-tools.yml && \
+    echo "https://repo.anaconda.com/pkgs/main/linux-64/setuptools-40.8.0-py36_0.tar.bz2" >> amplicon-parasite-tools.yml && \
+    echo "https://repo.anaconda.com/pkgs/main/linux-64/cryptography-2.3-py36hb7f436b_0.tar.bz2" >> amplicon-parasite-tools.yml && \
+    echo "https://repo.anaconda.com/pkgs/main/linux-64/jinja2-2.10-py36_0.tar.bz2" >> amplicon-parasite-tools.yml && \
+    echo "https://repo.anaconda.com/pkgs/main/linux-64/wheel-0.33.1-py36_0.tar.bz2" >> amplicon-parasite-tools.yml && \
+    echo "https://repo.anaconda.com/pkgs/main/linux-64/pip-19.0.3-py36_0.tar.bz2" >> amplicon-parasite-tools.yml && \
+    echo "https://repo.anaconda.com/pkgs/main/linux-64/pyopenssl-19.0.0-py36_0.tar.bz2" >> amplicon-parasite-tools.yml && \
+    echo "https://repo.anaconda.com/pkgs/main/linux-64/urllib3-1.24.1-py36_0.tar.bz2" >> amplicon-parasite-tools.yml && \
+    echo "https://repo.anaconda.com/pkgs/main/linux-64/requests-2.21.0-py36_0.tar.bz2" >> amplicon-parasite-tools.yml && \
+    echo "https://repo.anaconda.com/pkgs/main/linux-64/conda-4.6.11-py36_0.tar.bz2" >> amplicon-parasite-tools.yml && \
+    echo "https://repo.anaconda.com/pkgs/main/linux-64/conda-build-3.17.8-py36_0.tar.bz2" >> amplicon-parasite-tools.yml
+
+RUN conda create -n amplicon-parasite-tools --file amplicon-parasite-tools.yml && \
+    conda run -n amplicon-parasite-tools conda list && \
+    conda clean -afy && \
+    find /opt/conda/ -follow -type f -name '*.a' -delete && \
+    find /opt/conda/ -follow -type f -name '*.js.map' -delete
+
+ENV PATH='/opt/conda/envs/amplicon-parasite-tools/bin:/opt/conda/condabin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin' \
+    CONDA_PREFIX='/opt/conda/envs/amplicon-parasite-tools' \
+    CONDA_DEFAULT_ENV='amplicon-parasite-tools' \
+    CONDA_PROMPT_MODIFIER='(amplicon-parasite-tools) '
+
+RUN echo ". /opt/conda/etc/profile.d/conda.sh" > ~/.bashrc && \
+    echo "conda activate amplicon-parasite-tools" >> ~/.bashrc

--- a/pipelines/amplicon-snp-calling-parasite/AmpliconSNPCallingParasite.wdl
+++ b/pipelines/amplicon-snp-calling-parasite/AmpliconSNPCallingParasite.wdl
@@ -1,0 +1,132 @@
+version 1.0
+
+import "../../structs/ReferenceSequence.wdl"
+
+workflow AmpliconSNPCallingParasite {
+  input {
+    File input_bam
+    File input_bam_index
+    String output_basename
+    ReferenceSequence reference
+
+    File mpileup_targets_vcf
+    Int? mpileup_min_base_quality
+    Int? mpileup_max_depth
+
+    Int? call_ploidy
+
+    Int? filter_min_depth
+    Int? filter_min_quality
+    Int? filter_min_mapping_quality
+
+    Int? preemptible_tries
+    String docker
+  }
+
+  call CallAndFilterSNPsFromPileups {
+    input:
+      input_bam = input_bam,
+      input_bam_index = input_bam_index,
+      output_basename = output_basename,
+      reference = reference,
+      mpileup_targets_vcf = mpileup_targets_vcf,
+      mpileup_min_base_quality = mpileup_min_base_quality,
+      mpileup_max_depth = mpileup_max_depth,
+      call_ploidy = call_ploidy,
+      filter_min_depth = filter_min_depth,
+      filter_min_quality = filter_min_quality,
+      filter_min_mapping_quality = filter_min_mapping_quality,
+      preemptible_tries = preemptible_tries,
+      docker = docker
+  }
+
+  output {
+    File output_pileup_vcf = CallAndFilterSNPsFromPileups.output_pileup_vcf
+    File output_unfiltered_calls_vcf = CallAndFilterSNPsFromPileups.output_unfiltered_calls_vcf
+    File output_filtered_calls_vcf = CallAndFilterSNPsFromPileups.output_filtered_calls_vcf
+  }
+}
+
+task CallAndFilterSNPsFromPileups {
+  input {
+    File input_bam
+    File input_bam_index
+    String output_basename
+    ReferenceSequence reference
+
+    File mpileup_targets_vcf
+    Int? mpileup_min_base_quality
+    Int? mpileup_max_depth
+
+    Int? call_ploidy
+
+    Int? filter_min_depth
+    Int? filter_min_quality
+    Int? filter_min_mapping_quality
+
+    Int? preemptible_tries
+    String docker
+  }
+
+  Float bam_size = size(input_bam, "GiB")
+  Float ref_size = size(reference.ref_fasta, "GiB") + size(reference.ref_fasta_index, "GiB") + size(reference.ref_dict, "GiB")
+  Float disk_multiplier = 2.5
+  Int disk_size = ceil(bam_size + ref_size + (disk_multiplier * bam_size) + 20)
+
+  String output_pileup_vcf_ = output_basename + ".pileup.vcf"
+  String output_unfiltered_calls_vcf_ = output_basename + ".unfiltered.calls.vcf"
+  String output_filtered_calls_vcf_ = output_basename + ".filtered.calls.vcf"
+
+  command {
+    set -euo pipefail
+
+    echo "* * * * ~{default="2" call_ploidy}" > ploidy.txt
+
+    bcftools mpileup \
+      --min-BQ ~{default="20" mpileup_min_base_quality} \
+      --annotate FORMAT/AD,FORMAT/DP \
+      --max-depth ~{default="50000" mpileup_max_depth} \
+      --targets-file ~{mpileup_targets_vcf} \
+      --fasta-ref ~{reference.ref_fasta} \
+      --output-type v \
+      ~{input_bam} \
+      > ~{output_pileup_vcf_}
+
+    bcftools call \
+      --no-version \
+      --multiallelic-caller \
+      --keep-alts \
+      --skip-variants indels \
+      --ploidy-file ploidy.txt \
+      --output-type u \
+      < ~{output_pileup_vcf_} \
+      > ~{output_unfiltered_calls_vcf_}
+
+    bcftools filter \
+      --mode + \
+      --soft-filter LowDepth \
+      --exclude FORMAT/DP\<~{default="8" filter_min_depth} \
+      --output-type v \
+      < ~{output_unfiltered_calls_vcf_} |
+    bcftools filter \
+      --mode + \
+      --soft-filter LowQual \
+      --exclude '%QUAL<~{default="15" filter_min_quality} || MQ<~{default="20" filter_min_mapping_quality}' \
+      --output-type v \
+      > ~{output_filtered_calls_vcf_}
+  }
+
+  runtime {
+    docker: docker
+    preemptible: select_first([preemptible_tries, 5])
+    cpu: "1"
+    memory: "3.75 GiB"
+    disks: "local-disk " + disk_size + " HDD"
+  }
+
+  output {
+    File output_pileup_vcf = "~{output_pileup_vcf_}"
+    File output_unfiltered_calls_vcf = "~{output_unfiltered_calls_vcf_}"
+    File output_filtered_calls_vcf = "~{output_filtered_calls_vcf_}"
+  }
+}

--- a/pipelines/amplicon-snp-calling-parasite/input_files/RCN15267.json
+++ b/pipelines/amplicon-snp-calling-parasite/input_files/RCN15267.json
@@ -1,0 +1,17 @@
+{
+  "AmpliconSNPCallingParasite.input_bam": "gs://broad-dsde-methods-malariagen/parasite/test-data/RCN15267.PfD37.cram",
+  "AmpliconSNPCallingParasite.input_bam_index": "gs://broad-dsde-methods-malariagen/parasite/test-data/RCN15267.PfD37.cram.crai",
+  "AmpliconSNPCallingParasite.output_basename": "RCN15267",
+  "AmpliconSNPCallingParasite.reference": {
+    "ref_fasta": "gs://broad-dsde-methods-malariagen/parasite/references/PfD37/Pfalciparum_contigs.fasta",
+    "ref_dict": "gs://broad-dsde-methods-malariagen/parasite/references/PfD37/Pfalciparum_contigs.fasta.dict",
+    "ref_ann": "gs://broad-dsde-methods-malariagen/parasite/references/PfD37/Pfalciparum_contigs.fasta.ann",
+    "ref_sa": "gs://broad-dsde-methods-malariagen/parasite/references/PfD37/Pfalciparum_contigs.fasta.sa",
+    "ref_amb": "gs://broad-dsde-methods-malariagen/parasite/references/PfD37/Pfalciparum_contigs.fasta.amb",
+    "ref_bwt": "gs://broad-dsde-methods-malariagen/parasite/references/PfD37/Pfalciparum_contigs.fasta.bwt",
+    "ref_fasta_index": "gs://broad-dsde-methods-malariagen/parasite/references/PfD37/Pfalciparum_contigs.fasta.fai",
+    "ref_pac": "gs://broad-dsde-methods-malariagen/parasite/references/PfD37/Pfalciparum_contigs.fasta.pac"
+  },
+  "AmpliconSNPCallingParasite.mpileup_targets_vcf": "gs://broad-dsde-methods-malariagen/parasite/test-data/Pf_GRC1v1.0.PfD37.annotation.vcf",
+  "AmpliconSNPCallingParasite.docker": "us.gcr.io/broad-dsde-methods/malariagen/parasite/amplicon-parasite-tools:latest"
+}

--- a/pipelines/amplicon-snp-calling-parasite/input_files/RCN15267.json
+++ b/pipelines/amplicon-snp-calling-parasite/input_files/RCN15267.json
@@ -4,7 +4,7 @@
   "AmpliconSNPCallingParasite.output_basename": "RCN15267",
   "AmpliconSNPCallingParasite.reference": {
     "ref_fasta": "gs://broad-dsde-methods-malariagen/parasite/references/PfD37/Pfalciparum_contigs.fasta",
-    "ref_dict": "gs://broad-dsde-methods-malariagen/parasite/references/PfD37/Pfalciparum_contigs.fasta.dict",
+    "ref_dict": "gs://broad-dsde-methods-malariagen/parasite/references/PfD37/Pfalciparum_contigs.dict",
     "ref_ann": "gs://broad-dsde-methods-malariagen/parasite/references/PfD37/Pfalciparum_contigs.fasta.ann",
     "ref_sa": "gs://broad-dsde-methods-malariagen/parasite/references/PfD37/Pfalciparum_contigs.fasta.sa",
     "ref_amb": "gs://broad-dsde-methods-malariagen/parasite/references/PfD37/Pfalciparum_contigs.fasta.amb",


### PR DESCRIPTION
Very basic port of Stage 1, Step 3 of the amplicon SNP calling parasite pipeline. Adds a Dockerfile (for a conda environment that contains all necessary tools), a single-task WDL, and a test JSON.

Note that the test JSON points to a CRAM and a VCF (containing targets for collecting pileups) which have been "lifted over"---i.e., in contrast to files produced by the original pipeline, which performed alignment to a reference containing separate contigs for each panel target, these files are with respect to the full reference.

In putting this together, I discovered other issues in upstream steps that may need to be corrected (in addition to aligning against the full reference) before we can run GATK/Picard-based comparisons against this baseline. For example, Step 2 does not produce a valid CRAM file according to Picard ValidateSamFile. There are also some issues with unmapped/split reads that I'd like to understand.

We can fix up things and/or reorganize things as we move along, this is just to get us started.

Closes #37.