### PR TITLE
Performance improvements / Operations improvements

### DIFF
--- a/pipelines/SNP-genotyping-vector/farm5/SNPGenotyping.wdl
+++ b/pipelines/SNP-genotyping-vector/farm5/SNPGenotyping.wdl
@@ -52,4 +52,7 @@ workflow SNPGenotyping {
     File output_vcf_index = UnifiedGenotyper.output_vcf_index
     File zarr_output = VcfToZarr.zarr_output
   }
+  meta {
+    allowNestedInputs: true
+  }
 }

--- a/pipelines/SNP-genotyping-vector/gcp/SNPGenotyping.wdl
+++ b/pipelines/SNP-genotyping-vector/gcp/SNPGenotyping.wdl
@@ -52,4 +52,7 @@ workflow SNPGenotyping {
     File output_vcf_index = UnifiedGenotyper.output_vcf_index
     File zarr_output = VcfToZarr.zarr_output
   }
+  meta {
+    allowNestedInputs: true
+  }
 }

--- a/pipelines/short-read-alignment-and-genotyping-vector/farm5/ShortReadAlignmentAndGenotyping.wdl
+++ b/pipelines/short-read-alignment-and-genotyping-vector/farm5/ShortReadAlignmentAndGenotyping.wdl
@@ -66,4 +66,7 @@ workflow ShortReadAlignmentAndGenotyping {
     File output_vcf_index = SNPGenotyping.output_vcf_index
     File zarr_output = SNPGenotyping.zarr_output
   }
+  meta {
+    allowNestedInputs: true
+  }
 }

--- a/pipelines/short-read-alignment-and-genotyping-vector/gcp/ShortReadAlignmentAndGenotyping.wdl
+++ b/pipelines/short-read-alignment-and-genotyping-vector/gcp/ShortReadAlignmentAndGenotyping.wdl
@@ -66,4 +66,7 @@ workflow ShortReadAlignmentAndGenotyping {
     File output_vcf_index = SNPGenotyping.output_vcf_index
     File zarr_output = SNPGenotyping.zarr_output
   }
+  meta {
+    allowNestedInputs: true
+  }
 }

--- a/pipelines/short-read-alignment-and-genotyping-vector/gcp/input_files/small/AV0148-C.json
+++ b/pipelines/short-read-alignment-and-genotyping-vector/gcp/input_files/small/AV0148-C.json
@@ -1,7 +1,7 @@
 {
   "ShortReadAlignmentAndGenotyping.sample_id": "AV0148-C",
   "ShortReadAlignmentAndGenotyping.output_basename": "AV0148-C",
-  "ShortReadAlignmentAndGenotyping.input_file": "gs://broad-gotc-dev-storage/malariaGEN/ag1000g-phase1-minimal/lanelets.tsv",
+  "ShortReadAlignmentAndGenotyping.input_file": "gs://broad-gotc-dev-storage/malariaGEN/ag1000g-phase1-minimal/lanelets_gs.tsv",
   "ShortReadAlignmentAndGenotyping.alleles_vcf": "gs://broad-gotc-dev-storage/malariaGEN/vo_agam_production/resources/observatory/ag.allsites.nonN.vcf.gz",
   "ShortReadAlignmentAndGenotyping.alleles_vcf_index": "gs://broad-gotc-dev-storage/malariaGEN/vo_agam_production/resources/observatory/ag.allsites.nonN.vcf.gz.tbi",
   "ShortReadAlignmentAndGenotyping.reference": {

--- a/pipelines/short-read-alignment-vector/farm5/ShortReadAlignment.wdl
+++ b/pipelines/short-read-alignment-vector/farm5/ShortReadAlignment.wdl
@@ -201,4 +201,7 @@ workflow ShortReadAlignment {
     File samtools_flagstat_report_file = SamtoolsFlagStat.report_file
     File callable_loci_summary_file = GatkCallableLoci.summary_file
   }
+  meta {
+    allowNestedInputs: true
+  }
 }

--- a/pipelines/short-read-alignment-vector/gcp/ShortReadAlignment.wdl
+++ b/pipelines/short-read-alignment-vector/gcp/ShortReadAlignment.wdl
@@ -201,4 +201,7 @@ workflow ShortReadAlignment {
     File samtools_flagstat_report_file = SamtoolsFlagStat.report_file
     File callable_loci_summary_file = GatkCallableLoci.summary_file
   }
+  meta {
+    allowNestedInputs: true
+  }
 }

--- a/structs/gcp/RunTimeSettings.wdl
+++ b/structs/gcp/RunTimeSettings.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
 struct RunTimeSettings {
-  Int? preemptible_tries
+  Int preemptible_tries
   String gatk_docker
   String picard_docker
   String bwa_docker

--- a/tasks/farm5/Alignment.wdl
+++ b/tasks/farm5/Alignment.wdl
@@ -21,7 +21,6 @@ workflow Alignment {
     String input_fastq1
     String input_fastq2
     String output_file_basename
-
     ReferenceSequence reference
     RunTimeSettings runTimeSettings
   }
@@ -90,5 +89,8 @@ workflow Alignment {
 
   output {
     File output_bam = SetNmMdAndUqTags.output_bam
+  }
+  meta {
+    allowNestedInputs: true
   }
 }

--- a/tasks/farm5/SNPGenotypingTasks.wdl
+++ b/tasks/farm5/SNPGenotypingTasks.wdl
@@ -10,12 +10,18 @@ task UnifiedGenotyper {
     File alleles_vcf
     File alleles_vcf_index
     String output_vcf_filename
+
+    String singularity_image = runTimeSettings.gatk_singularity_image
+    Int num_cpu = 4
+    Int memory = 3000
+    String? lsf_group
+    String? lsf_queue
     ReferenceSequence reference
     RunTimeSettings runTimeSettings
   }
 
   command {
-    java -XX:GCTimeLimit=50 -XX:GCHeapFreeLimit=10 -Xmx3500m \
+    java -XX:GCTimeLimit=50 -XX:GCHeapFreeLimit=10 -Xmx~{memory}m \
           -jar /usr/GenomeAnalysisTK.jar \
           -T UnifiedGenotyper \
           -I ~{input_bam} \
@@ -50,11 +56,11 @@ task UnifiedGenotyper {
           -XA ReadPosRankSumTest
   }
   runtime {
-    singularity: runTimeSettings.gatk_singularity_image
-    memory: 3000
-    cpu: "1"
-    lsf_group: select_first([runTimeSettings.lsf_group, "malaria-dk"])
-    lsf_queue: select_first([runTimeSettings.lsf_queue, "normal"])
+    singularity: singularity_image
+    cpu: num_cpu
+    memory: memory
+    lsf_group: select_first([lsf_group, runTimeSettings.lsf_group, "malaria-dk"])
+    lsf_queue: select_first([lsf_queue, runTimeSettings.lsf_queue, "normal"])
   }
   output {
     File output_vcf = output_vcf_filename
@@ -68,6 +74,12 @@ task VcfToZarr {
     String sample_id
     String output_zarr_file_name
     String output_log_file_name
+
+    String singularity_image = runTimeSettings.vcftozarr_singularity_image
+    Int num_cpu = 2
+    Int memory = 3000
+    String? lsf_group
+    String? lsf_queue
     RunTimeSettings runTimeSettings
   }
 
@@ -91,11 +103,11 @@ task VcfToZarr {
         --zip
   }
   runtime {
-    singularity: runTimeSettings.vcftozarr_singularity_image
-    memory: 3000
-    cpu: "1"
-    lsf_group: select_first([runTimeSettings.lsf_group, "malaria-dk"])
-    lsf_queue: select_first([runTimeSettings.lsf_queue, "normal"])
+    singularity: singularity_image
+    cpu: num_cpu
+    memory: memory
+    lsf_group: select_first([lsf_group, runTimeSettings.lsf_group, "malaria-dk"])
+    lsf_queue: select_first([lsf_queue, runTimeSettings.lsf_queue, "normal"])
   }
   output {
     File output_log_file = output_log_file_name

--- a/tasks/farm5/ShortReadAlignmentTasks.wdl
+++ b/tasks/farm5/ShortReadAlignmentTasks.wdl
@@ -7,6 +7,12 @@ task SplitUpInputFile {
   input {
     File input_file
     String sample_id
+
+    String singularity_image = runTimeSettings.lftp_singularity_image
+    Int num_cpu = 1
+    Int memory = 3000
+    String? lsf_group
+    String? lsf_queue
     RunTimeSettings runTimeSettings
   }
 
@@ -30,11 +36,11 @@ task SplitUpInputFile {
   }
 
   runtime {
-    singularity: runTimeSettings.lftp_singularity_image
-    memory: 3000
-    cpu: "1"
-    lsf_group: select_first([runTimeSettings.lsf_group, "malaria-dk"])
-    lsf_queue: select_first([runTimeSettings.lsf_queue, "normal"])
+    singularity: singularity_image
+    cpu: num_cpu
+    memory: memory
+    lsf_group: select_first([lsf_group, runTimeSettings.lsf_group, "malaria-dk"])
+    lsf_queue: select_first([lsf_queue, runTimeSettings.lsf_queue, "normal"])
   }
 
   output {
@@ -46,6 +52,12 @@ task Ftp {
   input {
     String input_string
     String output_filename = basename(input_string)
+
+    String singularity_image = runTimeSettings.lftp_singularity_image
+    Int num_cpu = 1
+    Int memory = 3000
+    String? lsf_group
+    String? lsf_queue
     RunTimeSettings runTimeSettings
   }
 
@@ -60,11 +72,11 @@ task Ftp {
   }
 
   runtime {
-    singularity: runTimeSettings.lftp_singularity_image
-    memory: 3000
-    cpu: "1"
-    lsf_group: select_first([runTimeSettings.lsf_group, "malaria-dk"])
-    lsf_queue: select_first([runTimeSettings.lsf_queue, "normal"])
+    singularity: singularity_image
+    cpu: num_cpu
+    memory: memory
+    lsf_group: select_first([lsf_group, runTimeSettings.lsf_group, "malaria-dk"])
+    lsf_queue: select_first([lsf_queue, runTimeSettings.lsf_queue, "normal"])
   }
 
   output {
@@ -76,6 +88,12 @@ task CramToBam {
   input {
     File input_file
     String output_filename
+
+    String singularity_image = runTimeSettings.samtools_singularity_image
+    Int num_cpu = 2
+    Int memory = 3000
+    String? lsf_group
+    String? lsf_queue
     ReferenceSequence reference
     RunTimeSettings runTimeSettings
   }
@@ -92,11 +110,11 @@ task CramToBam {
   }
 
   runtime {
-    singularity: runTimeSettings.samtools_singularity_image
-    memory: 3000
-    cpu: "2"
-    lsf_group: select_first([runTimeSettings.lsf_group, "malaria-dk"])
-    lsf_queue: select_first([runTimeSettings.lsf_queue, "normal"])
+    singularity: singularity_image
+    cpu: num_cpu
+    memory: memory
+    lsf_group: select_first([lsf_group, runTimeSettings.lsf_group, "malaria-dk"])
+    lsf_queue: select_first([lsf_queue, runTimeSettings.lsf_queue, "normal"])
   }
 
   output {
@@ -109,11 +127,17 @@ task RevertSam {
   input {
     File input_file
     String output_filename
+
+    String singularity_image = runTimeSettings.picard_singularity_image
+    Int num_cpu = 1
+    Int memory = 4000
+    String? lsf_group
+    String? lsf_queue
     RunTimeSettings runTimeSettings
   }
 
   command {
-    java -Xmx3500m -jar /bin/picard.jar \
+    java -Xmx~{memory}m -jar /bin/picard.jar \
       RevertSam \
       INPUT=~{input_file} \
       OUTPUT=~{output_filename} \
@@ -126,10 +150,11 @@ task RevertSam {
   }
 
   runtime {
-    singularity: runTimeSettings.picard_singularity_image
-    memory: 4000
-    lsf_group: select_first([runTimeSettings.lsf_group, "malaria-dk"])
-    lsf_queue: select_first([runTimeSettings.lsf_queue, "normal"])
+    singularity: singularity_image
+    cpu: num_cpu
+    memory: memory
+    lsf_group: select_first([lsf_group, runTimeSettings.lsf_group, "malaria-dk"])
+    lsf_queue: select_first([lsf_queue, runTimeSettings.lsf_queue, "normal"])
   }
 
   output {
@@ -142,11 +167,17 @@ task SamToFastq {
     File input_file
     String output_fastq1_filename
     String output_fastq2_filename
+
+    String singularity_image = runTimeSettings.picard_singularity_image
+    Int num_cpu = 1
+    Int memory = 4000
+    String? lsf_group
+    String? lsf_queue
     RunTimeSettings runTimeSettings
   }
 
   command {
-    java -Xmx3500m -jar /bin/picard.jar \
+    java -Xmx~{memory}m -jar /bin/picard.jar \
       SamToFastq \
       INPUT=~{input_file} \
       FASTQ=~{output_fastq1_filename} \
@@ -155,10 +186,11 @@ task SamToFastq {
   }
 
   runtime {
-    singularity: runTimeSettings.picard_singularity_image
-    memory: 4000
-    lsf_group: select_first([runTimeSettings.lsf_group, "malaria-dk"])
-    lsf_queue: select_first([runTimeSettings.lsf_queue, "normal"])
+    singularity: singularity_image
+    cpu: num_cpu
+    memory: memory
+    lsf_group: select_first([lsf_group, runTimeSettings.lsf_group, "malaria-dk"])
+    lsf_queue: select_first([lsf_queue, runTimeSettings.lsf_queue, "normal"])
   }
 
   output {
@@ -175,6 +207,11 @@ task ReadAlignment {
     File fastq2
     String output_sam_basename
 
+    String singularity_image = runTimeSettings.bwa_singularity_image
+    Int num_cpu = 4
+    Int memory = 4000
+    String? lsf_group
+    String? lsf_queue
     ReferenceSequence reference
     RunTimeSettings runTimeSettings
   }
@@ -194,11 +231,11 @@ task ReadAlignment {
     /bwa/bwa mem -M -t 4 -T 0 -R '@RG\tID:~{read_group_id}\tSM:~{sample_id}\tCN:SC\tPL:ILLUMINA' ~{reference.ref_fasta} ~{fastq1} ~{fastq2} > ~{output_sam_basename}.sam
   }
   runtime {
-      singularity: runTimeSettings.bwa_singularity_image
-      memory: 4000
-      cpu: "4"
-      lsf_group: select_first([runTimeSettings.lsf_group, "malaria-dk"])
-      lsf_queue: select_first([runTimeSettings.lsf_queue, "normal"])
+    singularity: singularity_image
+    cpu: num_cpu
+    memory: memory
+    lsf_group: select_first([lsf_group, runTimeSettings.lsf_group, "malaria-dk"])
+    lsf_queue: select_first([lsf_queue, runTimeSettings.lsf_queue, "normal"])
   }
   output {
     File output_sam = "~{output_sam_basename}.sam"
@@ -209,6 +246,12 @@ task ReadAlignmentPostProcessing {
   input {
     File input_sam
     String output_bam_basename
+
+    String singularity_image = runTimeSettings.samtools_singularity_image
+    Int num_cpu = 2
+    Int memory = 3000
+    String? lsf_group
+    String? lsf_queue
     RunTimeSettings runTimeSettings
   }
 
@@ -225,11 +268,11 @@ task ReadAlignmentPostProcessing {
   }
 
   runtime {
-    singularity: runTimeSettings.samtools_singularity_image
-    memory: 3000
-    cpu: "2"
-    lsf_group: select_first([runTimeSettings.lsf_group, "malaria-dk"])
-    lsf_queue: select_first([runTimeSettings.lsf_queue, "normal"])
+    singularity: singularity_image
+    cpu: num_cpu
+    memory: memory
+    lsf_group: select_first([lsf_group, runTimeSettings.lsf_group, "malaria-dk"])
+    lsf_queue: select_first([lsf_queue, runTimeSettings.lsf_queue, "normal"])
   }
   output {
     File output_bam = "~{output_bam_basename}.bam"
@@ -240,12 +283,18 @@ task SetNmMdAndUqTags {
   input {
     File input_bam
     String output_bam_basename
+
+    String singularity_image = runTimeSettings.picard_singularity_image
+    Int num_cpu = 1
+    Int memory = 4000
+    String? lsf_group
+    String? lsf_queue
     ReferenceSequence reference
     RunTimeSettings runTimeSettings
   }
 
   command {
-    java -Xmx3500m -jar /bin/picard.jar \
+    java -Xmx~{memory}m -jar /bin/picard.jar \
       SetNmMdAndUqTags \
       INPUT=~{input_bam} \
       OUTPUT=~{output_bam_basename}.bam \
@@ -253,10 +302,11 @@ task SetNmMdAndUqTags {
       IS_BISULFITE_SEQUENCE=false
   }
   runtime {
-    singularity: runTimeSettings.picard_singularity_image
-    memory: 4000
-    lsf_group: select_first([runTimeSettings.lsf_group, "malaria-dk"])
-    lsf_queue: select_first([runTimeSettings.lsf_queue, "normal"])
+    singularity: singularity_image
+    cpu: num_cpu
+    memory: memory
+    lsf_group: select_first([lsf_group, runTimeSettings.lsf_group, "malaria-dk"])
+    lsf_queue: select_first([lsf_queue, runTimeSettings.lsf_queue, "normal"])
   }
   output {
     File output_bam = "~{output_bam_basename}.bam"
@@ -267,20 +317,27 @@ task MergeSamFiles {
   input {
     Array[File] input_files
     String output_filename
+
+    String singularity_image = runTimeSettings.picard_singularity_image
+    Int num_cpu = 1
+    Int memory = 4000
+    String? lsf_group
+    String? lsf_queue
     RunTimeSettings runTimeSettings
   }
 
   command {
-    java -Xmx3500m -jar /bin/picard.jar \
+    java -Xmx~{memory}m -jar /bin/picard.jar \
       MergeSamFiles \
       INPUT=~{sep=' INPUT=' input_files} \
       OUTPUT=~{output_filename}
   }
   runtime {
-    singularity: runTimeSettings.picard_singularity_image
-    memory: 4000
-    lsf_group: select_first([runTimeSettings.lsf_group, "malaria-dk"])
-    lsf_queue: select_first([runTimeSettings.lsf_queue, "normal"])
+    singularity: singularity_image
+    cpu: num_cpu
+    memory: memory
+    lsf_group: select_first([lsf_group, runTimeSettings.lsf_group, "malaria-dk"])
+    lsf_queue: select_first([lsf_queue, runTimeSettings.lsf_queue, "normal"])
   }
   output {
     File output_file = output_filename
@@ -291,6 +348,12 @@ task MarkDuplicates {
   input {
     File input_bam
     String output_filename
+
+    String singularity_image = runTimeSettings.biobambam_singularity_image
+    Int num_cpu = 1
+    Int memory = 2000
+    String? lsf_group
+    String? lsf_queue
     RunTimeSettings runTimeSettings
   }
 
@@ -298,10 +361,11 @@ task MarkDuplicates {
     /usr/local/bin/bammarkduplicates I=~{input_bam} O=~{output_filename} index=1
   }
   runtime {
-    singularity: runTimeSettings.biobambam_singularity_image
-    memory: 2000
-    lsf_group: select_first([runTimeSettings.lsf_group, "malaria-dk"])
-    lsf_queue: select_first([runTimeSettings.lsf_queue, "normal"])
+    singularity: singularity_image
+    cpu: num_cpu
+    memory: memory
+    lsf_group: select_first([lsf_group, runTimeSettings.lsf_group, "malaria-dk"])
+    lsf_queue: select_first([lsf_queue, runTimeSettings.lsf_queue, "normal"])
   }
   output {
     File output_file = output_filename
@@ -315,12 +379,18 @@ task RealignerTargetCreator {
     File input_bam_index
     File? known_indels_vcf
     String output_interval_list_filename
+
+    String singularity_image = runTimeSettings.gatk_singularity_image
+    Int num_cpu = 1
+    Int memory = 4000
+    String? lsf_group
+    String? lsf_queue
     ReferenceSequence reference
     RunTimeSettings runTimeSettings
   }
 
   command {
-    java -XX:GCTimeLimit=50 -XX:GCHeapFreeLimit=10 -Xmx3500m \
+    java -XX:GCTimeLimit=50 -XX:GCHeapFreeLimit=10 -Xmx~{memory}m \
           -jar /usr/GenomeAnalysisTK.jar \
           -T RealignerTargetCreator \
           -I ~{input_bam} \
@@ -329,10 +399,11 @@ task RealignerTargetCreator {
           -o ~{output_interval_list_filename}
   }
   runtime {
-    singularity: runTimeSettings.gatk_singularity_image
-    memory: 4000
-    lsf_group: select_first([runTimeSettings.lsf_group, "malaria-dk"])
-    lsf_queue: select_first([runTimeSettings.lsf_queue, "normal"])
+    singularity: singularity_image
+    cpu: num_cpu
+    memory: memory
+    lsf_group: select_first([lsf_group, runTimeSettings.lsf_group, "malaria-dk"])
+    lsf_queue: select_first([lsf_queue, runTimeSettings.lsf_queue, "normal"])
   }
   output {
     File output_interval_list_file = output_interval_list_filename
@@ -346,12 +417,18 @@ task IndelRealigner {
     File? known_indels_vcf
     File interval_list_file
     String output_bam_filename
+
+    String singularity_image = runTimeSettings.gatk_singularity_image
+    Int num_cpu = 1
+    Int memory = 8000
+    String? lsf_group
+    String? lsf_queue
     ReferenceSequence reference
     RunTimeSettings runTimeSettings
   }
 
   command {
-    java -XX:GCTimeLimit=50 -XX:GCHeapFreeLimit=10 -Xmx7500m \
+    java -XX:GCTimeLimit=50 -XX:GCHeapFreeLimit=10 -Xmx~{memory}m \
           -jar /usr/GenomeAnalysisTK.jar \
           -T IndelRealigner \
           -I ~{input_bam} \
@@ -361,10 +438,11 @@ task IndelRealigner {
           -o ~{output_bam_filename}
   }
   runtime {
-    singularity: runTimeSettings.gatk_singularity_image
-    memory: 8000
-    lsf_group: select_first([runTimeSettings.lsf_group, "malaria-dk"])
-    lsf_queue: select_first([runTimeSettings.lsf_queue, "normal"])
+    singularity: singularity_image
+    cpu: num_cpu
+    memory: memory
+    lsf_group: select_first([lsf_group, runTimeSettings.lsf_group, "malaria-dk"])
+    lsf_queue: select_first([lsf_queue, runTimeSettings.lsf_queue, "normal"])
   }
   output {
     File output_bam = output_bam_filename
@@ -375,6 +453,12 @@ task FixMateInformation {
   input {
     File input_file
     String output_bam_basename
+
+    String singularity_image = runTimeSettings.picard_singularity_image
+    Int num_cpu = 1
+    Int memory = 8000
+    String? lsf_group
+    String? lsf_queue
     RunTimeSettings runTimeSettings
   }
 
@@ -382,7 +466,7 @@ task FixMateInformation {
    set -e
    set -o pipefail
 
-    java -Xmx7000m -jar /bin/picard.jar \
+    java -Xmx~{memory}m -jar /bin/picard.jar \
       FixMateInformation \
       INPUT=~{input_file} \
       OUTPUT=~{output_bam_basename}.bam \
@@ -393,10 +477,11 @@ task FixMateInformation {
       mv ~{output_bam_basename}.bai ~{output_bam_basename}.bam.bai
   }
   runtime {
-    singularity: runTimeSettings.picard_singularity_image
-    memory: 4000
-    lsf_group: select_first([runTimeSettings.lsf_group, "malaria-dk"])
-    lsf_queue: select_first([runTimeSettings.lsf_queue, "normal"])
+    singularity: singularity_image
+    cpu: num_cpu
+    memory: memory
+    lsf_group: select_first([lsf_group, runTimeSettings.lsf_group, "malaria-dk"])
+    lsf_queue: select_first([lsf_queue, runTimeSettings.lsf_queue, "normal"])
   }
   output {
     File output_bam = "~{output_bam_basename}.bam"
@@ -411,12 +496,18 @@ task ValidateSamFile {
     String report_filename
     Int? max_output
     Array[String]? ignore
+
+    String singularity_image = runTimeSettings.picard_singularity_image
+    Int num_cpu = 1
+    Int memory = 4000
+    String? lsf_group
+    String? lsf_queue
     ReferenceSequence reference
     RunTimeSettings runTimeSettings
   }
 
   command {
-    java -Xmx3500m -jar /bin/picard.jar \
+    java -Xmx~{memory}m -jar /bin/picard.jar \
       ValidateSamFile \
       INPUT=~{input_file} \
       OUTPUT=~{report_filename} \
@@ -427,10 +518,11 @@ task ValidateSamFile {
       MODE=VERBOSE
   }
   runtime {
-    singularity: runTimeSettings.picard_singularity_image
-    memory: 4000
-    lsf_group: select_first([runTimeSettings.lsf_group, "malaria-dk"])
-    lsf_queue: select_first([runTimeSettings.lsf_queue, "normal"])
+    singularity: singularity_image
+    cpu: num_cpu
+    memory: memory
+    lsf_group: select_first([lsf_group, runTimeSettings.lsf_group, "malaria-dk"])
+    lsf_queue: select_first([lsf_queue, runTimeSettings.lsf_queue, "normal"])
   }
   output {
     File report_file = report_filename
@@ -441,6 +533,12 @@ task SamtoolsStats {
   input {
     File input_file
     String report_filename
+
+    String singularity_image = runTimeSettings.samtools_singularity_image
+    Int num_cpu = 1
+    Int memory = 2000
+    String? lsf_group
+    String? lsf_queue
     ReferenceSequence reference
     RunTimeSettings runTimeSettings
   }
@@ -455,11 +553,11 @@ task SamtoolsStats {
   }
 
   runtime {
-    singularity: runTimeSettings.samtools_singularity_image
-    cpu: "1"
-    memory: 1000
-    lsf_group: select_first([runTimeSettings.lsf_group, "malaria-dk"])
-    lsf_queue: select_first([runTimeSettings.lsf_queue, "normal"])
+    singularity: singularity_image
+    cpu: num_cpu
+    memory: memory
+    lsf_group: select_first([lsf_group, runTimeSettings.lsf_group, "malaria-dk"])
+    lsf_queue: select_first([lsf_queue, runTimeSettings.lsf_queue, "normal"])
   }
   output {
     File report_file = report_filename
@@ -471,6 +569,12 @@ task SamtoolsIdxStats {
     File input_bam
     File input_bam_index
     String report_filename
+
+    String singularity_image = runTimeSettings.samtools_singularity_image
+    Int num_cpu = 1
+    Int memory = 2000
+    String? lsf_group
+    String? lsf_queue
     RunTimeSettings runTimeSettings
   }
 
@@ -484,11 +588,11 @@ task SamtoolsIdxStats {
   }
 
   runtime {
-    singularity: runTimeSettings.samtools_singularity_image
-    cpu: "1"
-    memory: 2000
-    lsf_group: select_first([runTimeSettings.lsf_group, "malaria-dk"])
-    lsf_queue: select_first([runTimeSettings.lsf_queue, "normal"])
+    singularity: singularity_image
+    cpu: num_cpu
+    memory: memory
+    lsf_group: select_first([lsf_group, runTimeSettings.lsf_group, "malaria-dk"])
+    lsf_queue: select_first([lsf_queue, runTimeSettings.lsf_queue, "normal"])
   }
   output {
     File report_file = report_filename
@@ -499,6 +603,12 @@ task SamtoolsFlagStat {
   input {
     File input_bam
     String report_filename
+
+    String singularity_image = runTimeSettings.samtools_singularity_image
+    Int num_cpu = 1
+    Int memory = 2000
+    String? lsf_group
+    String? lsf_queue
     RunTimeSettings runTimeSettings
   }
 
@@ -512,11 +622,11 @@ task SamtoolsFlagStat {
   }
 
   runtime {
-    singularity: runTimeSettings.samtools_singularity_image
-    cpu: "1"
-    memory: 1000
-    lsf_group: select_first([runTimeSettings.lsf_group, "malaria-dk"])
-    lsf_queue: select_first([runTimeSettings.lsf_queue, "normal"])
+    singularity: singularity_image
+    cpu: num_cpu
+    memory: memory
+    lsf_group: select_first([lsf_group, runTimeSettings.lsf_group, "malaria-dk"])
+    lsf_queue: select_first([lsf_queue, runTimeSettings.lsf_queue, "normal"])
   }
   output {
     File report_file = report_filename
@@ -528,12 +638,18 @@ task GatkCallableLoci {
     File input_bam
     File input_bam_index
     String summary_filename
+
+    String singularity_image = runTimeSettings.gatk_singularity_image
+    Int num_cpu = 1
+    Int memory = 4000
+    String? lsf_group
+    String? lsf_queue
     ReferenceSequence reference
     RunTimeSettings runTimeSettings
   }
 
   command {
-    java -XX:GCTimeLimit=50 -XX:GCHeapFreeLimit=10 -Xmx3500m \
+    java -XX:GCTimeLimit=50 -XX:GCHeapFreeLimit=10 -Xmx~{memory}m \
           -jar /usr/GenomeAnalysisTK.jar \
           -T CallableLoci \
           -I ~{input_bam} \
@@ -542,10 +658,11 @@ task GatkCallableLoci {
           --minDepth 5
   }
   runtime {
-    singularity: runTimeSettings.gatk_singularity_image
-    memory: 4000
-    lsf_group: select_first([runTimeSettings.lsf_group, "malaria-dk"])
-    lsf_queue: select_first([runTimeSettings.lsf_queue, "normal"])
+    singularity: singularity_image
+    cpu: num_cpu
+    memory: memory
+    lsf_group: select_first([lsf_group, runTimeSettings.lsf_group, "malaria-dk"])
+    lsf_queue: select_first([lsf_queue, runTimeSettings.lsf_queue, "normal"])
   }
   output {
     File summary_file = summary_filename

--- a/tasks/gcp/Alignment.wdl
+++ b/tasks/gcp/Alignment.wdl
@@ -21,7 +21,6 @@ workflow Alignment {
     String input_fastq1
     String input_fastq2
     String output_file_basename
-
     ReferenceSequence reference
     RunTimeSettings runTimeSettings
   }
@@ -90,5 +89,8 @@ workflow Alignment {
 
   output {
     File output_bam = SetNmMdAndUqTags.output_bam
+  }
+  meta {
+    allowNestedInputs: true
   }
 }

--- a/tasks/gcp/SNPGenotypingTasks.wdl
+++ b/tasks/gcp/SNPGenotypingTasks.wdl
@@ -10,6 +10,10 @@ task UnifiedGenotyper {
     File alleles_vcf
     File alleles_vcf_index
     String output_vcf_filename
+
+    String docker = runTimeSettings.gatk_docker
+    Int preemptible_tries = runTimeSettings.preemptible_tries
+    Int num_cpu = 4
     ReferenceSequence reference
     RunTimeSettings runTimeSettings
   }
@@ -52,10 +56,10 @@ task UnifiedGenotyper {
           -XA ReadPosRankSumTest
   }
   runtime {
-    docker: runTimeSettings.gatk_docker
-    preemptible: runTimeSettings.preemptible_tries
-    cpu: "1"
-    memory: "3.75 GiB"
+    docker: docker
+    preemptible: preemptible_tries
+    cpu: num_cpu
+    memory: "15 GiB"
     disks: "local-disk " + disk_size + " HDD"
   }
   output {
@@ -70,6 +74,10 @@ task VcfToZarr {
     String sample_id
     String output_zarr_file_name
     String output_log_file_name
+
+    String docker = runTimeSettings.vcftozarr_docker
+    Int preemptible_tries = runTimeSettings.preemptible_tries
+    Int num_cpu = 1
     RunTimeSettings runTimeSettings
   }
 
@@ -95,10 +103,10 @@ task VcfToZarr {
         --zip
   }
   runtime {
-    docker: runTimeSettings.vcftozarr_docker
-    preemptible: runTimeSettings.preemptible_tries
-    cpu: "1"
-    memory: "3.75 GiB"
+    docker: docker
+    preemptible: preemptible_tries
+    cpu: num_cpu
+    memory: "7.5 GiB"
     disks: "local-disk " + disk_size + " HDD"
   }
   output {

--- a/tasks/gcp/ShortReadAlignmentTasks.wdl
+++ b/tasks/gcp/ShortReadAlignmentTasks.wdl
@@ -7,6 +7,10 @@ task SplitUpInputFile {
   input {
     File input_file
     String sample_id
+
+    String docker = runTimeSettings.lftp_docker
+    Int preemptible_tries = runTimeSettings.preemptible_tries
+    Int num_cpu = 1
     RunTimeSettings runTimeSettings
   }
 
@@ -30,9 +34,9 @@ task SplitUpInputFile {
   }
 
   runtime {
-    docker: runTimeSettings.lftp_docker
-    preemptible: runTimeSettings.preemptible_tries
-    cpu: "1"
+    docker: docker
+    preemptible: preemptible_tries
+    cpu: num_cpu
     memory: "3.75 GiB"
   }
 
@@ -45,6 +49,10 @@ task Ftp {
   input {
     String input_string
     String output_filename = basename(input_string)
+
+    String docker = runTimeSettings.lftp_docker
+    Int preemptible_tries = runTimeSettings.preemptible_tries
+    Int num_cpu = 1
     RunTimeSettings runTimeSettings
   }
 
@@ -59,9 +67,9 @@ task Ftp {
   }
 
   runtime {
-    docker: runTimeSettings.lftp_docker
-    preemptible: runTimeSettings.preemptible_tries
-    cpu: "1"
+    docker: docker
+    preemptible: preemptible_tries
+    cpu: num_cpu
     memory: "3.75 GiB"
     disks: "local-disk 100 HDD"
   }
@@ -75,6 +83,10 @@ task CramToBam {
   input {
     File input_file
     String output_filename
+
+    String docker = runTimeSettings.samtools_docker
+    Int preemptible_tries = runTimeSettings.preemptible_tries
+    Int num_cpu = 2
     ReferenceSequence reference
     RunTimeSettings runTimeSettings
   }
@@ -93,9 +105,9 @@ task CramToBam {
   }
 
   runtime {
-    docker: runTimeSettings.samtools_docker
-    preemptible: runTimeSettings.preemptible_tries
-    cpu: "2"
+    docker: docker
+    preemptible: preemptible_tries
+    cpu: num_cpu
     memory: "3.75 GiB"
     disks: "local-disk " + disk_size + " HDD"
   }
@@ -110,6 +122,10 @@ task RevertSam {
   input {
     File input_file
     String output_filename
+
+    String docker = runTimeSettings.picard_docker
+    Int preemptible_tries = runTimeSettings.preemptible_tries
+    Int num_cpu = 1
     RunTimeSettings runTimeSettings
   }
 
@@ -129,8 +145,9 @@ task RevertSam {
   }
 
   runtime {
-    docker: runTimeSettings.picard_docker
-    preemptible: runTimeSettings.preemptible_tries
+    docker: docker
+    preemptible: preemptible_tries
+    cpu: num_cpu
     memory: "3.75 GiB"
     disks: "local-disk " + disk_size + " HDD"
   }
@@ -145,6 +162,10 @@ task SamToFastq {
     File input_file
     String output_fastq1_filename
     String output_fastq2_filename
+
+    String docker = runTimeSettings.picard_docker
+    Int preemptible_tries = runTimeSettings.preemptible_tries
+    Int num_cpu = 1
     RunTimeSettings runTimeSettings
   }
 
@@ -160,8 +181,9 @@ task SamToFastq {
   }
 
   runtime {
-    docker: runTimeSettings.picard_docker
-    preemptible: runTimeSettings.preemptible_tries
+    docker: docker
+    preemptible: preemptible_tries
+    cpu: num_cpu
     memory: "3.75 GiB"
     disks: "local-disk " + disk_size + " HDD"
   }
@@ -180,6 +202,9 @@ task ReadAlignment {
     File fastq2
     String output_sam_basename
 
+    String docker = runTimeSettings.bwa_docker
+    Int preemptible_tries = runTimeSettings.preemptible_tries
+    Int num_cpu = 16
     ReferenceSequence reference
     RunTimeSettings runTimeSettings
   }
@@ -205,9 +230,9 @@ task ReadAlignment {
     /bwa/bwa mem -M -t 16 -T 0 -R '@RG\tID:~{read_group_id}\tSM:~{sample_id}\tCN:SC\tPL:ILLUMINA' ~{reference.ref_fasta} ~{fastq1} ~{fastq2} > ~{output_sam_basename}.sam
   }
   runtime {
-    docker: runTimeSettings.bwa_docker
-    preemptible: runTimeSettings.preemptible_tries
-    cpu: "16"
+    docker: docker
+    preemptible: preemptible_tries
+    cpu: num_cpu
     memory: "15 GiB"
     disks: "local-disk " + disk_size + " HDD"
   }
@@ -220,6 +245,10 @@ task ReadAlignmentPostProcessing {
   input {
     File input_sam
     String output_bam_basename
+
+    String docker = runTimeSettings.samtools_docker
+    Int preemptible_tries = runTimeSettings.preemptible_tries
+    Int num_cpu = 2
     RunTimeSettings runTimeSettings
   }
 
@@ -238,9 +267,9 @@ task ReadAlignmentPostProcessing {
   }
 
   runtime {
-    docker: runTimeSettings.samtools_docker
-    preemptible: runTimeSettings.preemptible_tries
-    cpu: "2"
+    docker: docker
+    preemptible: preemptible_tries
+    cpu: num_cpu
     memory: "14 GiB"
     disks: "local-disk " + disk_size + " HDD"
   }
@@ -253,6 +282,10 @@ task SetNmMdAndUqTags {
   input {
     File input_bam
     String output_bam_basename
+
+    String docker = runTimeSettings.picard_docker
+    Int preemptible_tries = runTimeSettings.preemptible_tries
+    Int num_cpu = 1
     ReferenceSequence reference
     RunTimeSettings runTimeSettings
   }
@@ -268,8 +301,9 @@ task SetNmMdAndUqTags {
       IS_BISULFITE_SEQUENCE=false
   }
   runtime {
-    docker: runTimeSettings.picard_docker
-    preemptible: runTimeSettings.preemptible_tries
+    docker: docker
+    preemptible: preemptible_tries
+    cpu: num_cpu
     memory: "3.75 GiB"
     disks: "local-disk " + disk_size + " HDD"
   }
@@ -282,6 +316,10 @@ task MergeSamFiles {
   input {
     Array[File] input_files
     String output_filename
+
+    String docker = runTimeSettings.picard_docker
+    Int preemptible_tries = runTimeSettings.preemptible_tries
+    Int num_cpu = 1
     RunTimeSettings runTimeSettings
   }
 
@@ -294,9 +332,9 @@ task MergeSamFiles {
       OUTPUT=~{output_filename}
   }
   runtime {
-    docker: runTimeSettings.picard_docker
-    preemptible: runTimeSettings.preemptible_tries
-    cpu: "1"
+    docker: docker
+    preemptible: preemptible_tries
+    cpu: num_cpu
     memory: "3.75 GiB"
     disks: "local-disk " + disk_size + " HDD"
   }
@@ -309,6 +347,10 @@ task MarkDuplicates {
   input {
     File input_bam
     String output_filename
+
+    String docker = runTimeSettings.biobambam_docker
+    Int preemptible_tries = runTimeSettings.preemptible_tries
+    Int num_cpu = 1
     RunTimeSettings runTimeSettings
   }
 
@@ -318,9 +360,9 @@ task MarkDuplicates {
     /usr/local/bin/bammarkduplicates I=~{input_bam} O=~{output_filename} index=1
   }
   runtime {
-    docker: runTimeSettings.biobambam_docker
-    preemptible: runTimeSettings.preemptible_tries
-    cpu: "1"
+    docker: docker
+    preemptible: preemptible_tries
+    cpu: num_cpu
     disks: "local-disk " + disk_size + " HDD"
     memory: "3.75 GiB"
   }
@@ -336,6 +378,10 @@ task RealignerTargetCreator {
     File input_bam_index
     File? known_indels_vcf
     String output_interval_list_filename
+
+    String docker = runTimeSettings.gatk_docker
+    Int preemptible_tries = runTimeSettings.preemptible_tries
+    Int num_cpu = 1
     ReferenceSequence reference
     RunTimeSettings runTimeSettings
   }
@@ -352,9 +398,9 @@ task RealignerTargetCreator {
           -o ~{output_interval_list_filename}
   }
   runtime {
-    docker: runTimeSettings.gatk_docker
-    preemptible: runTimeSettings.preemptible_tries
-    cpu: "1"
+    docker: docker
+    preemptible: preemptible_tries
+    cpu: num_cpu
     memory: "3.75 GiB"
     disks: "local-disk " + disk_size + " HDD"
   }
@@ -370,6 +416,10 @@ task IndelRealigner {
     File? known_indels_vcf
     File interval_list_file
     String output_bam_filename
+
+    String docker = runTimeSettings.gatk_docker
+    Int preemptible_tries = runTimeSettings.preemptible_tries
+    Int num_cpu = 1
     ReferenceSequence reference
     RunTimeSettings runTimeSettings
   }
@@ -387,9 +437,9 @@ task IndelRealigner {
           -o ~{output_bam_filename}
   }
   runtime {
-    docker: runTimeSettings.gatk_docker
-    preemptible: runTimeSettings.preemptible_tries
-    cpu: "1"
+    docker: docker
+    preemptible: preemptible_tries
+    cpu: num_cpu
     memory: "7.5 GiB"
     disks: "local-disk " + disk_size + " HDD"
   }
@@ -402,6 +452,10 @@ task FixMateInformation {
   input {
     File input_file
     String output_bam_basename
+
+    String docker = runTimeSettings.picard_docker
+    Int preemptible_tries = runTimeSettings.preemptible_tries
+    Int num_cpu = 1
     RunTimeSettings runTimeSettings
   }
 
@@ -422,9 +476,9 @@ task FixMateInformation {
       mv ~{output_bam_basename}.bai ~{output_bam_basename}.bam.bai
   }
   runtime {
-    docker: runTimeSettings.picard_docker
-    preemptible: runTimeSettings.preemptible_tries
-    cpu: "1"
+    docker: docker
+    preemptible: preemptible_tries
+    cpu: num_cpu
     memory: "7.5 GiB"
     disks: "local-disk " + disk_size + " HDD"
   }
@@ -441,6 +495,10 @@ task ValidateSamFile {
     String report_filename
     Int? max_output
     Array[String]? ignore
+
+    String docker = runTimeSettings.picard_docker
+    Int preemptible_tries = runTimeSettings.preemptible_tries
+    Int num_cpu = 1
     ReferenceSequence reference
     RunTimeSettings runTimeSettings
   }
@@ -460,9 +518,9 @@ task ValidateSamFile {
       MODE=VERBOSE
   }
   runtime {
-    docker: runTimeSettings.picard_docker
-    preemptible: runTimeSettings.preemptible_tries
-    cpu: "1"
+    docker: docker
+    preemptible: preemptible_tries
+    cpu: num_cpu
     memory: "3.75 GiB"
     disks: "local-disk " + disk_size + " HDD"
   }
@@ -475,6 +533,10 @@ task SamtoolsStats {
   input {
     File input_file
     String report_filename
+
+    String docker = runTimeSettings.samtools_docker
+    Int preemptible_tries = runTimeSettings.preemptible_tries
+    Int num_cpu = 1
     ReferenceSequence reference
     RunTimeSettings runTimeSettings
   }
@@ -493,8 +555,8 @@ task SamtoolsStats {
 
   runtime {
     docker: runTimeSettings.samtools_docker
-    preemptible: runTimeSettings.preemptible_tries
-    cpu: "1"
+    preemptible: preemptible_tries
+    cpu: num_cpu
     memory: "7.5 GiB"
     disks: "local-disk " + disk_size + " HDD"
   }
@@ -508,6 +570,10 @@ task SamtoolsIdxStats {
     File input_bam
     File input_bam_index
     String report_filename
+
+    String docker = runTimeSettings.samtools_docker
+    Int preemptible_tries = runTimeSettings.preemptible_tries
+    Int num_cpu = 1
     RunTimeSettings runTimeSettings
   }
 
@@ -523,9 +589,9 @@ task SamtoolsIdxStats {
   }
 
   runtime {
-    docker: runTimeSettings.samtools_docker
-    preemptible: runTimeSettings.preemptible_tries
-    cpu: "1"
+    docker: docker
+    preemptible: preemptible_tries
+    cpu: num_cpu
     memory: "3.75 GiB"
     disks: "local-disk " + disk_size + " HDD"
   }
@@ -538,6 +604,10 @@ task SamtoolsFlagStat {
   input {
     File input_bam
     String report_filename
+
+    String docker = runTimeSettings.samtools_docker
+    Int preemptible_tries = runTimeSettings.preemptible_tries
+    Int num_cpu = 1
     RunTimeSettings runTimeSettings
   }
 
@@ -553,9 +623,9 @@ task SamtoolsFlagStat {
   }
 
   runtime {
-    docker: runTimeSettings.samtools_docker
-    preemptible: runTimeSettings.preemptible_tries
-    cpu: "1"
+    docker: docker
+    preemptible: preemptible_tries
+    cpu: num_cpu
     memory: "3.75 GiB"
     disks: "local-disk " + disk_size + " HDD"
   }
@@ -569,6 +639,10 @@ task GatkCallableLoci {
     File input_bam
     File input_bam_index
     String summary_filename
+
+    String docker = runTimeSettings.gatk_docker
+    Int preemptible_tries = runTimeSettings.preemptible_tries
+    Int num_cpu = 1
     ReferenceSequence reference
     RunTimeSettings runTimeSettings
   }
@@ -585,9 +659,9 @@ task GatkCallableLoci {
           --minDepth 5
   }
   runtime {
-    docker: runTimeSettings.gatk_docker
-    preemptible: runTimeSettings.preemptible_tries
-    cpu: "1"
+    docker: docker
+    preemptible: preemptible_tries
+    cpu: num_cpu
     memory: "3.75 GiB"
     disks: "local-disk " + disk_size + " HDD"
   }


### PR DESCRIPTION
Allow inputs to override number of cpus, memory, and lsf settings.
Allow the inputs json to override the singularity image too.
Increasing number of cpus for UnifiedGenotyper.
Increasing number of cpus and memory for VCFToSampleZarr task
Allow passing of docker, preemptible tries and num_cpus to tasks under GCP.