### PR TITLE
Farm5 singularity to docker

### DIFF
--- a/dockerfiles/Import/Dockerfile
+++ b/dockerfiles/Import/Dockerfile
@@ -1,0 +1,17 @@
+FROM ubuntu:18.04
+ARG DEBIAN_FRONTEND=noninteractive
+ARG IRODS_VERSION=4.2.8
+RUN apt-get update \
+    && apt-get install -yq \
+      software-properties-common \
+      wget \
+      python3 \
+      python3-pip \
+    && pip3 install pandas \
+    && wget -qO - https://packages.irods.org/irods-signing-key.asc | apt-key add - \
+    && echo "deb [arch=amd64] https://packages.irods.org/apt/ $(lsb_release -sc) main" | tee /etc/apt/sources.list.d/renci-irods.list \
+    && apt-get update \
+    && apt-get install -yq irods-icommands=${IRODS_VERSION} \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* \
+    && sudo update-alternatives --install /usr/bin/python python /usr/bin/python3 10 \

--- a/dockerfiles/README.md
+++ b/dockerfiles/README.md
@@ -38,6 +38,9 @@ Contains the sample_select_variants python script
 ### WhatsHap
 Contains the latest version of WhatsHap https://whatshap.readthedocs.io/en/latest/
 
+### Import
+A farm5-specific docker image, providing dependencies for the iRODS import and batch processing workflows.
+
 ## Mosquito short read alignment pipeline
 
 - bwa 0.7.15 - `docker build . --tag=bwa:0.7.15 --build-arg version=v0.7.15`
@@ -49,4 +52,5 @@ Contains the latest version of WhatsHap https://whatshap.readthedocs.io/en/lates
 - samplevcftozarr - `docker build . --tag=samplevcftozarr:1.0`
 - sampleselectvariants - `docker build . --tag=sampleselectvarians:1.0`
 - whatshap - `docker build . --tag=whatshap:1.0`
+- import - `docker build . --tag=sangerpathogens/irods:4.1.12`
 

--- a/pipelines/SNP-genotyping-vector/farm5/input_files/small/AV0148-C.json
+++ b/pipelines/SNP-genotyping-vector/farm5/input_files/small/AV0148-C.json
@@ -18,12 +18,5 @@
   "SNPGenotyping.runTimeSettings": {
     "lsf_group": "pathdev",
     "lsf_queue": "normal",
-    "bwa_singularity_image": "bwa.0.7.15_v0.1.2.sif",
-    "samtools_singularity_image": "samtools.1.4.1_v0.1.2.sif",
-    "picard_singularity_image": "picard.2.9.2_v0.1.3.sif",
-    "biobambam_singularity_image": "biobambam2.0.73_v0.1.2.sif",
-    "gatk_singularity_image": "gatk.3.7.0_v0.1.2.sif",
-    "vcftozarr_singularity_image": "samplevcftozarr_v0.1.5.sif",
-    "lftp_singularity_image": "lftp_v0.1.4.sif"
   }
 }

--- a/pipelines/batch-import-short-read-alignment-and-genotyping-vector/farm5/input_files/small/batch_size4.json
+++ b/pipelines/batch-import-short-read-alignment-and-genotyping-vector/farm5/input_files/small/batch_size4.json
@@ -16,15 +16,6 @@
   "BatchImportShortReadAlignmentAndGenotyping.runTimeSettings": {
     "lsf_group": "pathdev",
     "lsf_queue": "normal",
-    "bwa_singularity_image": "bwa.0.7.15_v0.1.2.sif",
-    "samtools_singularity_image": "samtools.1.4.1_v0.1.2.sif",
-    "picard_singularity_image": "picard.2.9.2_v0.1.3.sif",
-    "biobambam_singularity_image": "biobambam2.0.73_v0.1.2.sif",
-    "gatk_singularity_image": "gatk.3.7.0_v0.1.2.sif",
-    "vcftozarr_singularity_image": "samplevcftozarr_v0.1.5.sif",
-    "lftp_singularity_image": "lftp_v0.1.4.sif",
-    "irods_singularity_image" : "irods_4.1.12.img",
-    "binder_singularity_image" : "binder2.4.3.img "
   }
 
 

--- a/pipelines/batch-import-short-read-alignment-and-genotyping-vector/farm5/input_files/validation/batch_size10_validation.json
+++ b/pipelines/batch-import-short-read-alignment-and-genotyping-vector/farm5/input_files/validation/batch_size10_validation.json
@@ -16,15 +16,6 @@
   "BatchImportShortReadAlignmentAndGenotyping.runTimeSettings": {
     "lsf_group": "pathdev",
     "lsf_queue": "normal",
-    "bwa_singularity_image": "bwa.0.7.15_v0.1.2.sif",
-    "samtools_singularity_image": "samtools.1.4.1_v0.1.2.sif",
-    "picard_singularity_image": "picard.2.9.2_v0.1.3.sif",
-    "biobambam_singularity_image": "biobambam2.0.73_v0.1.2.sif",
-    "gatk_singularity_image": "gatk.3.7.0_v0.1.2.sif",
-    "vcftozarr_singularity_image": "samplevcftozarr_v0.1.5.sif",
-    "lftp_singularity_image": "lftp_v0.1.4.sif",
-    "irods_singularity_image" : "irods_4.1.12.img",
-    "binder_singularity_image" : "binder2.4.3.img "
   }
 
 

--- a/pipelines/batch-import-short-read-alignment-and-genotyping-vector/farm5/input_files/validation/batch_size28_ag3.2_validation.json
+++ b/pipelines/batch-import-short-read-alignment-and-genotyping-vector/farm5/input_files/validation/batch_size28_ag3.2_validation.json
@@ -16,15 +16,6 @@
   "BatchImportShortReadAlignmentAndGenotyping.runTimeSettings": {
     "lsf_group": "pathdev",
     "lsf_queue": "normal",
-    "bwa_singularity_image": "bwa.0.7.15_v0.1.2.sif",
-    "samtools_singularity_image": "samtools.1.4.1_v0.1.2.sif",
-    "picard_singularity_image": "picard.2.9.2_v0.1.3.sif",
-    "biobambam_singularity_image": "biobambam2.0.73_v0.1.2.sif",
-    "gatk_singularity_image": "gatk.3.7.0_v0.1.2.sif",
-    "vcftozarr_singularity_image": "samplevcftozarr_v0.1.5.sif",
-    "lftp_singularity_image": "lftp_v0.1.4.sif",
-    "irods_singularity_image" : "irods_4.1.12.img",
-    "binder_singularity_image" : "binder2.4.3.img "
   }
 
 

--- a/pipelines/short-read-alignment-and-genotyping-vector/farm5/input_files/small/AV0148-C.json
+++ b/pipelines/short-read-alignment-and-genotyping-vector/farm5/input_files/small/AV0148-C.json
@@ -16,12 +16,5 @@
   "ShortReadAlignmentAndGenotyping.runTimeSettings": {
     "lsf_group": "pathdev",
     "lsf_queue": "normal",
-    "bwa_singularity_image": "bwa.0.7.15_v0.1.2.sif",
-    "samtools_singularity_image": "samtools.1.4.1_v0.1.2.sif",
-    "picard_singularity_image": "picard.2.9.2_v0.1.3.sif",
-    "biobambam_singularity_image": "biobambam2.0.73_v0.1.2.sif",
-    "gatk_singularity_image": "gatk.3.7.0_v0.1.2.sif",
-    "vcftozarr_singularity_image": "samplevcftozarr_v0.1.5.sif",
-    "lftp_singularity_image": "lftp_v0.1.4.sif"
   }
 }

--- a/pipelines/short-read-alignment-and-genotyping-vector/farm5/input_files/validation/AA0052-C.json
+++ b/pipelines/short-read-alignment-and-genotyping-vector/farm5/input_files/validation/AA0052-C.json
@@ -16,12 +16,5 @@
   "ShortReadAlignmentAndGenotyping.runTimeSettings": {
     "lsf_group": "pathdev",
     "lsf_queue": "normal",
-    "bwa_singularity_image": "bwa.0.7.15_v0.1.2.sif",
-    "samtools_singularity_image": "samtools.1.4.1_v0.1.2.sif",
-    "picard_singularity_image": "picard.2.9.2_v0.1.3.sif",
-    "biobambam_singularity_image": "biobambam2.0.73_v0.1.2.sif",
-    "gatk_singularity_image": "gatk.3.7.0_v0.1.2.sif",
-    "vcftozarr_singularity_image": "samplevcftozarr_v0.1.5.sif",
-    "lftp_singularity_image": "lftp_v0.1.4.sif"
   }
 }

--- a/pipelines/short-read-alignment-and-genotyping-vector/farm5/input_files/validation/AB0252-C.json
+++ b/pipelines/short-read-alignment-and-genotyping-vector/farm5/input_files/validation/AB0252-C.json
@@ -16,12 +16,5 @@
   "ShortReadAlignmentAndGenotyping.runTimeSettings": {
     "lsf_group": "pathdev",
     "lsf_queue": "normal",
-    "bwa_singularity_image": "bwa.0.7.15_v0.1.2.sif",
-    "samtools_singularity_image": "samtools.1.4.1_v0.1.2.sif",
-    "picard_singularity_image": "picard.2.9.2_v0.1.3.sif",
-    "biobambam_singularity_image": "biobambam2.0.73_v0.1.2.sif",
-    "gatk_singularity_image": "gatk.3.7.0_v0.1.2.sif",
-    "vcftozarr_singularity_image": "samplevcftozarr_v0.1.5.sif",
-    "lftp_singularity_image": "lftp_v0.1.4.sif"
   }
 }

--- a/pipelines/short-read-alignment-and-genotyping-vector/farm5/input_files/validation/AC0010-C.json
+++ b/pipelines/short-read-alignment-and-genotyping-vector/farm5/input_files/validation/AC0010-C.json
@@ -16,12 +16,5 @@
   "ShortReadAlignmentAndGenotyping.runTimeSettings": {
     "lsf_group": "pathdev",
     "lsf_queue": "normal",
-    "bwa_singularity_image": "bwa.0.7.15_v0.1.2.sif",
-    "samtools_singularity_image": "samtools.1.4.1_v0.1.2.sif",
-    "picard_singularity_image": "picard.2.9.2_v0.1.3.sif",
-    "biobambam_singularity_image": "biobambam2.0.73_v0.1.2.sif",
-    "gatk_singularity_image": "gatk.3.7.0_v0.1.2.sif",
-    "vcftozarr_singularity_image": "samplevcftozarr_v0.1.5.sif",
-    "lftp_singularity_image": "lftp_v0.1.4.sif"
   }
 }

--- a/pipelines/short-read-alignment-and-genotyping-vector/farm5/input_files/validation/AJ0037-C.json
+++ b/pipelines/short-read-alignment-and-genotyping-vector/farm5/input_files/validation/AJ0037-C.json
@@ -16,12 +16,5 @@
   "ShortReadAlignmentAndGenotyping.runTimeSettings": {
     "lsf_group": "pathdev",
     "lsf_queue": "normal",
-    "bwa_singularity_image": "bwa.0.7.15_v0.1.2.sif",
-    "samtools_singularity_image": "samtools.1.4.1_v0.1.2.sif",
-    "picard_singularity_image": "picard.2.9.2_v0.1.3.sif",
-    "biobambam_singularity_image": "biobambam2.0.73_v0.1.2.sif",
-    "gatk_singularity_image": "gatk.3.7.0_v0.1.2.sif",
-    "vcftozarr_singularity_image": "samplevcftozarr_v0.1.5.sif",
-    "lftp_singularity_image": "lftp_v0.1.4.sif"
   }
 }

--- a/pipelines/short-read-alignment-and-genotyping-vector/farm5/input_files/validation/AN0131-C.json
+++ b/pipelines/short-read-alignment-and-genotyping-vector/farm5/input_files/validation/AN0131-C.json
@@ -16,12 +16,5 @@
   "ShortReadAlignmentAndGenotyping.runTimeSettings": {
     "lsf_group": "pathdev",
     "lsf_queue": "normal",
-    "bwa_singularity_image": "bwa.0.7.15_v0.1.2.sif",
-    "samtools_singularity_image": "samtools.1.4.1_v0.1.2.sif",
-    "picard_singularity_image": "picard.2.9.2_v0.1.3.sif",
-    "biobambam_singularity_image": "biobambam2.0.73_v0.1.2.sif",
-    "gatk_singularity_image": "gatk.3.7.0_v0.1.2.sif",
-    "vcftozarr_singularity_image": "samplevcftozarr_v0.1.5.sif",
-    "lftp_singularity_image": "lftp_v0.1.4.sif"
   }
 }

--- a/pipelines/short-read-alignment-and-genotyping-vector/farm5/input_files/validation/AN0280-Cx.json
+++ b/pipelines/short-read-alignment-and-genotyping-vector/farm5/input_files/validation/AN0280-Cx.json
@@ -16,12 +16,5 @@
   "ShortReadAlignmentAndGenotyping.runTimeSettings": {
     "lsf_group": "pathdev",
     "lsf_queue": "normal",
-    "bwa_singularity_image": "bwa.0.7.15_v0.1.2.sif",
-    "samtools_singularity_image": "samtools.1.4.1_v0.1.2.sif",
-    "picard_singularity_image": "picard.2.9.2_v0.1.3.sif",
-    "biobambam_singularity_image": "biobambam2.0.73_v0.1.2.sif",
-    "gatk_singularity_image": "gatk.3.7.0_v0.1.2.sif",
-    "vcftozarr_singularity_image": "samplevcftozarr_v0.1.5.sif",
-    "lftp_singularity_image": "lftp_v0.1.4.sif"
   }
 }

--- a/pipelines/short-read-alignment-and-genotyping-vector/farm5/input_files/validation/AN0326-C.json
+++ b/pipelines/short-read-alignment-and-genotyping-vector/farm5/input_files/validation/AN0326-C.json
@@ -16,12 +16,5 @@
   "ShortReadAlignmentAndGenotyping.runTimeSettings": {
     "lsf_group": "pathdev",
     "lsf_queue": "normal",
-    "bwa_singularity_image": "bwa.0.7.15_v0.1.2.sif",
-    "samtools_singularity_image": "samtools.1.4.1_v0.1.2.sif",
-    "picard_singularity_image": "picard.2.9.2_v0.1.3.sif",
-    "biobambam_singularity_image": "biobambam2.0.73_v0.1.2.sif",
-    "gatk_singularity_image": "gatk.3.7.0_v0.1.2.sif",
-    "vcftozarr_singularity_image": "samplevcftozarr_v0.1.5.sif",
-    "lftp_singularity_image": "lftp_v0.1.4.sif"
   }
 }

--- a/pipelines/short-read-alignment-and-genotyping-vector/farm5/input_files/validation/AR0078-C.json
+++ b/pipelines/short-read-alignment-and-genotyping-vector/farm5/input_files/validation/AR0078-C.json
@@ -16,12 +16,5 @@
   "ShortReadAlignmentAndGenotyping.runTimeSettings": {
     "lsf_group": "pathdev",
     "lsf_queue": "normal",
-    "bwa_singularity_image": "bwa.0.7.15_v0.1.2.sif",
-    "samtools_singularity_image": "samtools.1.4.1_v0.1.2.sif",
-    "picard_singularity_image": "picard.2.9.2_v0.1.3.sif",
-    "biobambam_singularity_image": "biobambam2.0.73_v0.1.2.sif",
-    "gatk_singularity_image": "gatk.3.7.0_v0.1.2.sif",
-    "vcftozarr_singularity_image": "samplevcftozarr_v0.1.5.sif",
-    "lftp_singularity_image": "lftp_v0.1.4.sif"
   }
 }

--- a/pipelines/short-read-alignment-and-genotyping-vector/farm5/input_files/validation/AZ0156-C.json
+++ b/pipelines/short-read-alignment-and-genotyping-vector/farm5/input_files/validation/AZ0156-C.json
@@ -16,12 +16,5 @@
   "ShortReadAlignmentAndGenotyping.runTimeSettings": {
     "lsf_group": "pathdev",
     "lsf_queue": "normal",
-    "bwa_singularity_image": "bwa.0.7.15_v0.1.2.sif",
-    "samtools_singularity_image": "samtools.1.4.1_v0.1.2.sif",
-    "picard_singularity_image": "picard.2.9.2_v0.1.3.sif",
-    "biobambam_singularity_image": "biobambam2.0.73_v0.1.2.sif",
-    "gatk_singularity_image": "gatk.3.7.0_v0.1.2.sif",
-    "vcftozarr_singularity_image": "samplevcftozarr_v0.1.5.sif",
-    "lftp_singularity_image": "lftp_v0.1.4.sif"
   }
 }

--- a/pipelines/short-read-alignment-and-genotyping-vector/farm5/input_files/validation/BL0358-C.json
+++ b/pipelines/short-read-alignment-and-genotyping-vector/farm5/input_files/validation/BL0358-C.json
@@ -16,12 +16,5 @@
   "ShortReadAlignmentAndGenotyping.runTimeSettings": {
     "lsf_group": "pathdev",
     "lsf_queue": "normal",
-    "bwa_singularity_image": "bwa.0.7.15_v0.1.2.sif",
-    "samtools_singularity_image": "samtools.1.4.1_v0.1.2.sif",
-    "picard_singularity_image": "picard.2.9.2_v0.1.3.sif",
-    "biobambam_singularity_image": "biobambam2.0.73_v0.1.2.sif",
-    "gatk_singularity_image": "gatk.3.7.0_v0.1.2.sif",
-    "vcftozarr_singularity_image": "samplevcftozarr_v0.1.5.sif",
-    "lftp_singularity_image": "lftp_v0.1.4.sif"
   }
 }

--- a/pipelines/short-read-alignment-vector/farm5/input_files/AB0252-C.json
+++ b/pipelines/short-read-alignment-vector/farm5/input_files/AB0252-C.json
@@ -15,12 +15,5 @@
   "ShortReadAlignment.runTimeSettings": {
     "lsf_group": "pathdev",
     "lsf_queue": "normal",
-    "bwa_singularity_image": "bwa.0.7.15_v0.1.2.sif",
-    "samtools_singularity_image": "samtools.1.4.1_v0.1.2.sif",
-    "picard_singularity_image": "picard.2.9.2_v0.1.3.sif",
-    "biobambam_singularity_image": "biobambam2.0.73_v0.1.2.sif",
-    "gatk_singularity_image": "gatk.3.7.0_v0.1.2.sif",
-    "vcftozarr_singularity_image": "samplevcftozarr_v0.1.5.sif",
-    "lftp_singularity_image": "lftp_v0.1.4.sif"
   }
 }

--- a/pipelines/short-read-alignment-vector/farm5/input_files/AN0131-C.json
+++ b/pipelines/short-read-alignment-vector/farm5/input_files/AN0131-C.json
@@ -15,12 +15,5 @@
   "ShortReadAlignment.runTimeSettings": {
     "lsf_group": "pathdev",
     "lsf_queue": "normal",
-    "bwa_singularity_image": "bwa.0.7.15_v0.1.2.sif",
-    "samtools_singularity_image": "samtools.1.4.1_v0.1.2.sif",
-    "picard_singularity_image": "picard.2.9.2_v0.1.3.sif",
-    "biobambam_singularity_image": "biobambam2.0.73_v0.1.2.sif",
-    "gatk_singularity_image": "gatk.3.7.0_v0.1.2.sif",
-    "vcftozarr_singularity_image": "samplevcftozarr_v0.1.5.sif",
-    "lftp_singularity_image": "lftp_v0.1.4.sif"
   }
 }

--- a/pipelines/short-read-alignment-vector/farm5/input_files/small/AV0079-C.json
+++ b/pipelines/short-read-alignment-vector/farm5/input_files/small/AV0079-C.json
@@ -15,12 +15,5 @@
   "ShortReadAlignment.runTimeSettings": {
     "lsf_group": "pathdev",
     "lsf_queue": "normal",
-    "bwa_singularity_image": "bwa.0.7.15_v0.1.2.sif",
-    "samtools_singularity_image": "samtools.1.4.1_v0.1.2.sif",
-    "picard_singularity_image": "picard.2.9.2_v0.1.3.sif",
-    "biobambam_singularity_image": "biobambam2.0.73_v0.1.2.sif",
-    "gatk_singularity_image": "gatk.3.7.0_v0.1.2.sif",
-    "vcftozarr_singularity_image": "samplevcftozarr_v0.1.5.sif",
-    "lftp_singularity_image": "lftp_v0.1.4.sif"
   }
 }

--- a/pipelines/short-read-alignment-vector/farm5/input_files/small/AV0148-C.json
+++ b/pipelines/short-read-alignment-vector/farm5/input_files/small/AV0148-C.json
@@ -15,12 +15,5 @@
   "ShortReadAlignment.runTimeSettings": {
     "lsf_group": "pathdev",
     "lsf_queue": "normal",
-    "bwa_singularity_image": "bwa.0.7.15_v0.1.2.sif",
-    "samtools_singularity_image": "samtools.1.4.1_v0.1.2.sif",
-    "picard_singularity_image": "picard.2.9.2_v0.1.3.sif",
-    "biobambam_singularity_image": "biobambam2.0.73_v0.1.2.sif",
-    "gatk_singularity_image": "gatk.3.7.0_v0.1.2.sif",
-    "vcftozarr_singularity_image": "samplevcftozarr_v0.1.5.sif",
-    "lftp_singularity_image": "lftp_v0.1.4.sif"
   }
 }

--- a/structs/farm5/RunTimeSettings.wdl
+++ b/structs/farm5/RunTimeSettings.wdl
@@ -3,13 +3,4 @@ version 1.0
 struct RunTimeSettings {
   String? lsf_group
   String? lsf_queue
-  String bwa_singularity_image
-  String samtools_singularity_image
-  String picard_singularity_image
-  String biobambam_singularity_image
-  String gatk_singularity_image
-  String vcftozarr_singularity_image
-  String lftp_singularity_image
-  String binder_singularity_image
-  String irods_singularity_image
 }

--- a/tasks/farm5/ImportTasks.wdl
+++ b/tasks/farm5/ImportTasks.wdl
@@ -7,7 +7,7 @@ task ImportIRODS {
     String irods_path
     String sample_id
 
-    String docker_tag = "malaria-irods:4.1.12"
+    String docker_tag = "malaria-irods@sha256:adadaf506ac1d99dfc9a0eb2d8f4cad4527e1a0d00fbf18d8864155ce16038d8"
     Int num_cpu = 1
     Int memory = 1000
     String? lsf_group
@@ -55,7 +55,7 @@ task BatchSplitUpInputFile {
   input {
     File batch_sample_manifest_file
 
-    String docker_tag = "malaria-irods:4.1.12"
+    String docker_tag = "malaria-irods@sha256:adadaf506ac1d99dfc9a0eb2d8f4cad4527e1a0d00fbf18d8864155ce16038d8"
     Int num_cpu = 1
     Int memory = 3000
     String? lsf_group

--- a/tasks/farm5/ImportTasks.wdl
+++ b/tasks/farm5/ImportTasks.wdl
@@ -7,7 +7,7 @@ task ImportIRODS {
     String irods_path
     String sample_id
 
-    String singularity_image = runTimeSettings.irods_singularity_image
+    String docker_tag = "malaria-irods:4.1.12"
     Int num_cpu = 1
     Int memory = 1000
     String? lsf_group
@@ -30,7 +30,7 @@ task ImportIRODS {
   }
 
   runtime {
-    singularity: singularity_image
+    docker: docker_tag
     memory: memory
     cpu: num_cpu
     lsf_group: select_first([runTimeSettings.lsf_group, lsf_group, "pathdev"])
@@ -55,7 +55,7 @@ task BatchSplitUpInputFile {
   input {
     File batch_sample_manifest_file
 
-    String singularity_image = runTimeSettings.binder_singularity_image
+    String docker_tag = "malaria-irods:4.1.12"
     Int num_cpu = 1
     Int memory = 3000
     String? lsf_group
@@ -84,7 +84,7 @@ task BatchSplitUpInputFile {
   >>>
 
   runtime {
-    singularity: singularity_image 
+    docker: docker_tag 
     memory: memory
     cpu: num_cpu
     lsf_group: select_first([runTimeSettings.lsf_group, lsf_group, "pathdev"])

--- a/tasks/farm5/SNPGenotypingTasks.wdl
+++ b/tasks/farm5/SNPGenotypingTasks.wdl
@@ -11,7 +11,7 @@ task UnifiedGenotyper {
     File alleles_vcf_index
     String output_vcf_filename
 
-    String singularity_image = runTimeSettings.gatk_singularity_image
+    String docker_tag = "malaria-gatk3:3.7.0"
     Int num_cpu = 4
     Int memory = 3000
     String? lsf_group
@@ -56,7 +56,7 @@ task UnifiedGenotyper {
           -XA ReadPosRankSumTest
   }
   runtime {
-    singularity: singularity_image
+    docker: docker_tag
     cpu: num_cpu
     memory: memory
     lsf_group: select_first([runTimeSettings.lsf_group, lsf_group, "pathdev"])
@@ -75,7 +75,7 @@ task VcfToZarr {
     String output_zarr_file_name
     String output_log_file_name
 
-    String singularity_image = runTimeSettings.vcftozarr_singularity_image
+    String docker_tag = "malaria-samplevcftozarr:1.0.0"
     Int num_cpu = 2
     Int memory = 3000
     String? lsf_group
@@ -103,7 +103,7 @@ task VcfToZarr {
         --zip
   }
   runtime {
-    singularity: singularity_image
+    docker: docker_tag
     cpu: num_cpu
     memory: memory
     lsf_group: select_first([runTimeSettings.lsf_group, lsf_group, "pathdev"])

--- a/tasks/farm5/SNPGenotypingTasks.wdl
+++ b/tasks/farm5/SNPGenotypingTasks.wdl
@@ -11,7 +11,7 @@ task UnifiedGenotyper {
     File alleles_vcf_index
     String output_vcf_filename
 
-    String docker_tag = "malaria-gatk3:3.7.0"
+    String docker_tag = "malaria-gatk3@sha256:11dcafb2c5b574c8313942874ec8449b536adcc37c00bad149f1ef1a45012a28"
     Int num_cpu = 4
     Int memory = 3000
     String? lsf_group
@@ -75,7 +75,7 @@ task VcfToZarr {
     String output_zarr_file_name
     String output_log_file_name
 
-    String docker_tag = "malaria-samplevcftozarr:1.0.0"
+    String docker_tag = "malaria-samplevcftozarr@sha256:1baec1f2b253311bf834f8c5bf8c8169e765f738ac1972100027cbfa28329f2f"
     Int num_cpu = 2
     Int memory = 3000
     String? lsf_group

--- a/tasks/farm5/ShortReadAlignmentTasks.wdl
+++ b/tasks/farm5/ShortReadAlignmentTasks.wdl
@@ -228,7 +228,7 @@ task ReadAlignment {
     # platform [PL]: obtained from raw sequenced bam, but we can make this up for testing
     # study [DS]: obtained from raw sequenced bam, but we can make this up for testing
     # @rg ID:130508_HS22_09812_A_D1U5TACXX_4#48 LB:7206533 SM:AN0131-C CN:SC PL:ILLUMINA DS:1087-AN-HAPMAP-DONNELLY
-    /bwa/bwa mem -M -K 100000000 -t 4 -T 0 -R '@RG\tID:~{read_group_id}\tSM:~{sample_id}\tCN:SC\tPL:ILLUMINA' ~{reference.ref_fasta} ~{fastq1} ~{fastq2} > ~{output_sam_basename}.sam
+    bwa mem -M -K 100000000 -t 4 -T 0 -R '@RG\tID:~{read_group_id}\tSM:~{sample_id}\tCN:SC\tPL:ILLUMINA' ~{reference.ref_fasta} ~{fastq1} ~{fastq2} > ~{output_sam_basename}.sam
   }
   runtime {
     docker: docker_tag

--- a/tasks/farm5/ShortReadAlignmentTasks.wdl
+++ b/tasks/farm5/ShortReadAlignmentTasks.wdl
@@ -8,7 +8,7 @@ task SplitUpInputFile {
     File input_file
     String sample_id
 
-    String singularity_image = runTimeSettings.lftp_singularity_image
+    String docker_tag = "malaria-lftp:4.8.3"
     Int num_cpu = 1
     Int memory = 3000
     String? lsf_group
@@ -36,7 +36,7 @@ task SplitUpInputFile {
   }
 
   runtime {
-    singularity: singularity_image
+    docker: docker_tag
     cpu: num_cpu
     memory: memory
     lsf_group: select_first([runTimeSettings.lsf_group, lsf_group, "pathdev"])
@@ -53,7 +53,7 @@ task Ftp {
     String input_string
     String output_filename = basename(input_string)
 
-    String singularity_image = runTimeSettings.lftp_singularity_image
+    String docker_tag = "malaria-lftp:4.8.3"
     Int num_cpu = 1
     Int memory = 3000
     String? lsf_group
@@ -72,7 +72,7 @@ task Ftp {
   }
 
   runtime {
-    singularity: singularity_image
+    docker: docker_tag
     cpu: num_cpu
     memory: memory
     lsf_group: select_first([runTimeSettings.lsf_group, lsf_group, "pathdev"])
@@ -89,7 +89,7 @@ task CramToBam {
     File input_file
     String output_filename
 
-    String singularity_image = runTimeSettings.samtools_singularity_image
+    String docker_tag = "malaria-samtools:1.4.1"
     Int num_cpu = 2
     Int memory = 3000
     String? lsf_group
@@ -110,7 +110,7 @@ task CramToBam {
   }
 
   runtime {
-    singularity: singularity_image
+    docker: docker_tag
     cpu: num_cpu
     memory: memory
     lsf_group: select_first([runTimeSettings.lsf_group, lsf_group, "pathdev"])
@@ -128,7 +128,7 @@ task RevertSam {
     File input_file
     String output_filename
 
-    String singularity_image = runTimeSettings.picard_singularity_image
+    String docker_tag = "malaria-picard:2.9.2"
     Int num_cpu = 1
     Int memory = 4000
     String? lsf_group
@@ -150,7 +150,7 @@ task RevertSam {
   }
 
   runtime {
-    singularity: singularity_image
+    docker: docker_tag
     cpu: num_cpu
     memory: memory
     lsf_group: select_first([runTimeSettings.lsf_group, lsf_group, "pathdev"])
@@ -168,7 +168,7 @@ task SamToFastq {
     String output_fastq1_filename
     String output_fastq2_filename
 
-    String singularity_image = runTimeSettings.picard_singularity_image
+    String docker_tag = "malaria-picard:2.9.2"
     Int num_cpu = 1
     Int memory = 4000
     String? lsf_group
@@ -186,7 +186,7 @@ task SamToFastq {
   }
 
   runtime {
-    singularity: singularity_image
+    docker: docker_tag
     cpu: num_cpu
     memory: memory
     lsf_group: select_first([runTimeSettings.lsf_group, lsf_group, "pathdev"])
@@ -207,7 +207,7 @@ task ReadAlignment {
     File fastq2
     String output_sam_basename
 
-    String singularity_image = runTimeSettings.bwa_singularity_image
+    String docker_tag = "malaria-bwa:0.7.15"
     Int num_cpu = 4
     Int memory = 4000
     String? lsf_group
@@ -231,7 +231,7 @@ task ReadAlignment {
     /bwa/bwa mem -M -K 100000000 -t 4 -T 0 -R '@RG\tID:~{read_group_id}\tSM:~{sample_id}\tCN:SC\tPL:ILLUMINA' ~{reference.ref_fasta} ~{fastq1} ~{fastq2} > ~{output_sam_basename}.sam
   }
   runtime {
-    singularity: singularity_image
+    docker: docker_tag
     cpu: num_cpu
     memory: memory
     lsf_group: select_first([runTimeSettings.lsf_group, lsf_group, "pathdev"])
@@ -247,7 +247,7 @@ task ReadAlignmentPostProcessing {
     File input_sam
     String output_bam_basename
 
-    String singularity_image = runTimeSettings.samtools_singularity_image
+    String docker_tag = "malaria-samtools:1.4.1"
     Int num_cpu = 2
     Int memory = 3000
     String? lsf_group
@@ -268,7 +268,7 @@ task ReadAlignmentPostProcessing {
   }
 
   runtime {
-    singularity: singularity_image
+    docker: docker_tag
     cpu: num_cpu
     memory: memory
     lsf_group: select_first([runTimeSettings.lsf_group, lsf_group, "pathdev"])
@@ -284,7 +284,7 @@ task SetNmMdAndUqTags {
     File input_bam
     String output_bam_basename
 
-    String singularity_image = runTimeSettings.picard_singularity_image
+    String docker_tag = "malaria-picard:2.9.2"
     Int num_cpu = 1
     Int memory = 4000
     String? lsf_group
@@ -302,7 +302,7 @@ task SetNmMdAndUqTags {
       IS_BISULFITE_SEQUENCE=false
   }
   runtime {
-    singularity: singularity_image
+    docker: docker_tag
     cpu: num_cpu
     memory: memory
     lsf_group: select_first([runTimeSettings.lsf_group, lsf_group, "pathdev"])
@@ -318,7 +318,7 @@ task MergeSamFiles {
     Array[File] input_files
     String output_filename
 
-    String singularity_image = runTimeSettings.picard_singularity_image
+    String docker_tag = "malaria-picard:2.9.2"
     Int num_cpu = 1
     Int memory = 4000
     String? lsf_group
@@ -333,7 +333,7 @@ task MergeSamFiles {
       OUTPUT=~{output_filename}
   }
   runtime {
-    singularity: singularity_image
+    docker: docker_tag
     cpu: num_cpu
     memory: memory
     lsf_group: select_first([runTimeSettings.lsf_group, lsf_group, "pathdev"])
@@ -349,7 +349,7 @@ task MarkDuplicates {
     File input_bam
     String output_filename
 
-    String singularity_image = runTimeSettings.biobambam_singularity_image
+    String docker_tag = "malaria-biobambam:2.0.73"
     Int num_cpu = 1
     Int memory = 2000
     String? lsf_group
@@ -361,7 +361,7 @@ task MarkDuplicates {
     /usr/local/bin/bammarkduplicates I=~{input_bam} O=~{output_filename} index=1
   }
   runtime {
-    singularity: singularity_image
+    docker: docker_tag
     cpu: num_cpu
     memory: memory
     lsf_group: select_first([runTimeSettings.lsf_group, lsf_group, "pathdev"])
@@ -380,7 +380,7 @@ task RealignerTargetCreator {
     File? known_indels_vcf
     String output_interval_list_filename
 
-    String singularity_image = runTimeSettings.gatk_singularity_image
+    String docker_tag = "malaria-gatk3:3.7.0"
     Int num_cpu = 1
     Int memory = 4000
     String? lsf_group
@@ -399,7 +399,7 @@ task RealignerTargetCreator {
           -o ~{output_interval_list_filename}
   }
   runtime {
-    singularity: singularity_image
+    docker: docker_tag
     cpu: num_cpu
     memory: memory
     lsf_group: select_first([runTimeSettings.lsf_group, lsf_group, "pathdev"])
@@ -418,7 +418,7 @@ task IndelRealigner {
     File interval_list_file
     String output_bam_filename
 
-    String singularity_image = runTimeSettings.gatk_singularity_image
+    String docker_tag = "malaria-gatk3:3.7.0"
     Int num_cpu = 1
     Int memory = 8000
     String? lsf_group
@@ -438,7 +438,7 @@ task IndelRealigner {
           -o ~{output_bam_filename}
   }
   runtime {
-    singularity: singularity_image
+    docker: docker_tag
     cpu: num_cpu
     memory: memory
     lsf_group: select_first([runTimeSettings.lsf_group, lsf_group, "pathdev"])
@@ -454,7 +454,7 @@ task FixMateInformation {
     File input_file
     String output_bam_basename
 
-    String singularity_image = runTimeSettings.picard_singularity_image
+    String docker_tag = "malaria-picard:2.9.2"
     Int num_cpu = 1
     Int memory = 8000
     String? lsf_group
@@ -477,7 +477,7 @@ task FixMateInformation {
       mv ~{output_bam_basename}.bai ~{output_bam_basename}.bam.bai
   }
   runtime {
-    singularity: singularity_image
+    docker: docker_tag
     cpu: num_cpu
     memory: memory
     lsf_group: select_first([runTimeSettings.lsf_group, lsf_group, "pathdev"])
@@ -497,7 +497,7 @@ task ValidateSamFile {
     Int? max_output
     Array[String]? ignore
 
-    String singularity_image = runTimeSettings.picard_singularity_image
+    String docker_tag = "malaria-picard:2.9.2"
     Int num_cpu = 1
     Int memory = 4000
     String? lsf_group
@@ -518,7 +518,7 @@ task ValidateSamFile {
       MODE=VERBOSE
   }
   runtime {
-    singularity: singularity_image
+    docker: docker_tag
     cpu: num_cpu
     memory: memory
     lsf_group: select_first([runTimeSettings.lsf_group, lsf_group, "pathdev"])
@@ -534,7 +534,7 @@ task SamtoolsStats {
     File input_file
     String report_filename
 
-    String singularity_image = runTimeSettings.samtools_singularity_image
+    String docker_tag = "malaria-samtools:1.4.1"
     Int num_cpu = 1
     Int memory = 2000
     String? lsf_group
@@ -553,7 +553,7 @@ task SamtoolsStats {
   }
 
   runtime {
-    singularity: singularity_image
+    docker: docker_tag
     cpu: num_cpu
     memory: memory
     lsf_group: select_first([runTimeSettings.lsf_group, lsf_group, "pathdev"])
@@ -570,7 +570,7 @@ task SamtoolsIdxStats {
     File input_bam_index
     String report_filename
 
-    String singularity_image = runTimeSettings.samtools_singularity_image
+    String docker_tag = "malaria-samtools:1.4.1"
     Int num_cpu = 1
     Int memory = 2000
     String? lsf_group
@@ -588,7 +588,7 @@ task SamtoolsIdxStats {
   }
 
   runtime {
-    singularity: singularity_image
+    docker: docker_tag
     cpu: num_cpu
     memory: memory
     lsf_group: select_first([runTimeSettings.lsf_group, lsf_group, "pathdev"])
@@ -604,7 +604,7 @@ task SamtoolsFlagStat {
     File input_bam
     String report_filename
 
-    String singularity_image = runTimeSettings.samtools_singularity_image
+    String docker_tag = "malaria-samtools:1.4.1"
     Int num_cpu = 1
     Int memory = 2000
     String? lsf_group
@@ -622,7 +622,7 @@ task SamtoolsFlagStat {
   }
 
   runtime {
-    singularity: singularity_image
+    docker: docker_tag
     cpu: num_cpu
     memory: memory
     lsf_group: select_first([runTimeSettings.lsf_group, lsf_group, "pathdev"])
@@ -639,7 +639,7 @@ task GatkCallableLoci {
     File input_bam_index
     String summary_filename
 
-    String singularity_image = runTimeSettings.gatk_singularity_image
+    String docker_tag = "malaria-gatk3:3.7.0"
     Int num_cpu = 1
     Int memory = 4000
     String? lsf_group
@@ -658,7 +658,7 @@ task GatkCallableLoci {
           --minDepth 5
   }
   runtime {
-    singularity: singularity_image
+    docker: docker_tag
     cpu: num_cpu
     memory: memory
     lsf_group: select_first([runTimeSettings.lsf_group, lsf_group, "pathdev"])

--- a/tasks/farm5/ShortReadAlignmentTasks.wdl
+++ b/tasks/farm5/ShortReadAlignmentTasks.wdl
@@ -137,7 +137,7 @@ task RevertSam {
   }
 
   command {
-    java -Xmx~{memory}m -jar /bin/picard.jar \
+    picard -Xmx~{memory}m \
       RevertSam \
       INPUT=~{input_file} \
       OUTPUT=~{output_filename} \
@@ -177,7 +177,7 @@ task SamToFastq {
   }
 
   command {
-    java -Xmx~{memory}m -jar /bin/picard.jar \
+    picard -Xmx~{memory}m \
       SamToFastq \
       INPUT=~{input_file} \
       FASTQ=~{output_fastq1_filename} \
@@ -294,7 +294,7 @@ task SetNmMdAndUqTags {
   }
 
   command {
-    java -Xmx~{memory}m -jar /bin/picard.jar \
+    picard -Xmx~{memory}m \
       SetNmMdAndUqTags \
       INPUT=~{input_bam} \
       OUTPUT=~{output_bam_basename}.bam \
@@ -327,7 +327,7 @@ task MergeSamFiles {
   }
 
   command {
-    java -Xmx~{memory}m -jar /bin/picard.jar \
+    picard -Xmx~{memory}m \
       MergeSamFiles \
       INPUT=~{sep=' INPUT=' input_files} \
       OUTPUT=~{output_filename}
@@ -466,7 +466,7 @@ task FixMateInformation {
    set -e
    set -o pipefail
 
-    java -Xmx~{memory}m -jar /bin/picard.jar \
+    picard -Xmx~{memory}m \
       FixMateInformation \
       INPUT=~{input_file} \
       OUTPUT=~{output_bam_basename}.bam \
@@ -507,7 +507,7 @@ task ValidateSamFile {
   }
 
   command {
-    java -Xmx~{memory}m -jar /bin/picard.jar \
+    picard -Xmx~{memory}m \
       ValidateSamFile \
       INPUT=~{input_file} \
       OUTPUT=~{report_filename} \

--- a/tasks/farm5/ShortReadAlignmentTasks.wdl
+++ b/tasks/farm5/ShortReadAlignmentTasks.wdl
@@ -8,7 +8,7 @@ task SplitUpInputFile {
     File input_file
     String sample_id
 
-    String docker_tag = "malaria-lftp:4.8.3"
+    String docker_tag = "malaria-lftp@sha256:08f6ecb84d21a09f248749e65d5c90686030a99423c8e31101e9c98fe4992745"
     Int num_cpu = 1
     Int memory = 3000
     String? lsf_group
@@ -53,7 +53,7 @@ task Ftp {
     String input_string
     String output_filename = basename(input_string)
 
-    String docker_tag = "malaria-lftp:4.8.3"
+    String docker_tag = "malaria-lftp@sha256:08f6ecb84d21a09f248749e65d5c90686030a99423c8e31101e9c98fe4992745"
     Int num_cpu = 1
     Int memory = 3000
     String? lsf_group
@@ -89,7 +89,7 @@ task CramToBam {
     File input_file
     String output_filename
 
-    String docker_tag = "malaria-samtools:1.4.1"
+    String docker_tag = "malaria-samtools@sha256:e6f69efb1481e737cea07ae9e365457761e52720e559b28432b8495cec800c63"
     Int num_cpu = 2
     Int memory = 3000
     String? lsf_group
@@ -128,7 +128,7 @@ task RevertSam {
     File input_file
     String output_filename
 
-    String docker_tag = "malaria-picard:2.9.2"
+    String docker_tag = "malaria-picard@sha256:918e067454d1b6635c3f617eacfeb3c3984f771fe0b1aefd11a8878db661f9e8"
     Int num_cpu = 1
     Int memory = 4000
     String? lsf_group
@@ -168,7 +168,7 @@ task SamToFastq {
     String output_fastq1_filename
     String output_fastq2_filename
 
-    String docker_tag = "malaria-picard:2.9.2"
+    String docker_tag = "malaria-picard@sha256:918e067454d1b6635c3f617eacfeb3c3984f771fe0b1aefd11a8878db661f9e8"
     Int num_cpu = 1
     Int memory = 4000
     String? lsf_group
@@ -207,7 +207,7 @@ task ReadAlignment {
     File fastq2
     String output_sam_basename
 
-    String docker_tag = "malaria-bwa:0.7.15"
+    String docker_tag = "malaria-bwa@sha256:1504f6bacc2a2b8b5583f0782c9cd89c1a9c7db8d31bd5bbcfccc8470f24f5e0"
     Int num_cpu = 4
     Int memory = 4000
     String? lsf_group
@@ -247,7 +247,7 @@ task ReadAlignmentPostProcessing {
     File input_sam
     String output_bam_basename
 
-    String docker_tag = "malaria-samtools:1.4.1"
+    String docker_tag = "malaria-samtools@sha256:e6f69efb1481e737cea07ae9e365457761e52720e559b28432b8495cec800c63"
     Int num_cpu = 2
     Int memory = 3000
     String? lsf_group
@@ -284,7 +284,7 @@ task SetNmMdAndUqTags {
     File input_bam
     String output_bam_basename
 
-    String docker_tag = "malaria-picard:2.9.2"
+    String docker_tag = "malaria-picard@sha256:918e067454d1b6635c3f617eacfeb3c3984f771fe0b1aefd11a8878db661f9e8"
     Int num_cpu = 1
     Int memory = 4000
     String? lsf_group
@@ -318,7 +318,7 @@ task MergeSamFiles {
     Array[File] input_files
     String output_filename
 
-    String docker_tag = "malaria-picard:2.9.2"
+    String docker_tag = "malaria-picard@sha256:918e067454d1b6635c3f617eacfeb3c3984f771fe0b1aefd11a8878db661f9e8"
     Int num_cpu = 1
     Int memory = 4000
     String? lsf_group
@@ -349,7 +349,7 @@ task MarkDuplicates {
     File input_bam
     String output_filename
 
-    String docker_tag = "malaria-biobambam:2.0.73"
+    String docker_tag = "malaria-biobambam@sha256:b185800c292be69ad5928489b530b9a46b2057dea2380f845ba6925591fe62fc"
     Int num_cpu = 1
     Int memory = 2000
     String? lsf_group
@@ -380,7 +380,7 @@ task RealignerTargetCreator {
     File? known_indels_vcf
     String output_interval_list_filename
 
-    String docker_tag = "malaria-gatk3:3.7.0"
+    String docker_tag = "malaria-gatk3@sha256:11dcafb2c5b574c8313942874ec8449b536adcc37c00bad149f1ef1a45012a28"
     Int num_cpu = 1
     Int memory = 4000
     String? lsf_group
@@ -418,7 +418,7 @@ task IndelRealigner {
     File interval_list_file
     String output_bam_filename
 
-    String docker_tag = "malaria-gatk3:3.7.0"
+    String docker_tag = "malaria-gatk3@sha256:11dcafb2c5b574c8313942874ec8449b536adcc37c00bad149f1ef1a45012a28"
     Int num_cpu = 1
     Int memory = 8000
     String? lsf_group
@@ -454,7 +454,7 @@ task FixMateInformation {
     File input_file
     String output_bam_basename
 
-    String docker_tag = "malaria-picard:2.9.2"
+    String docker_tag = "malaria-picard@sha256:918e067454d1b6635c3f617eacfeb3c3984f771fe0b1aefd11a8878db661f9e8"
     Int num_cpu = 1
     Int memory = 8000
     String? lsf_group
@@ -497,7 +497,7 @@ task ValidateSamFile {
     Int? max_output
     Array[String]? ignore
 
-    String docker_tag = "malaria-picard:2.9.2"
+    String docker_tag = "malaria-picard@sha256:918e067454d1b6635c3f617eacfeb3c3984f771fe0b1aefd11a8878db661f9e8"
     Int num_cpu = 1
     Int memory = 4000
     String? lsf_group
@@ -534,7 +534,7 @@ task SamtoolsStats {
     File input_file
     String report_filename
 
-    String docker_tag = "malaria-samtools:1.4.1"
+    String docker_tag = "malaria-samtools@sha256:e6f69efb1481e737cea07ae9e365457761e52720e559b28432b8495cec800c63"
     Int num_cpu = 1
     Int memory = 2000
     String? lsf_group
@@ -570,7 +570,7 @@ task SamtoolsIdxStats {
     File input_bam_index
     String report_filename
 
-    String docker_tag = "malaria-samtools:1.4.1"
+    String docker_tag = "malaria-samtools@sha256:e6f69efb1481e737cea07ae9e365457761e52720e559b28432b8495cec800c63"
     Int num_cpu = 1
     Int memory = 2000
     String? lsf_group
@@ -604,7 +604,7 @@ task SamtoolsFlagStat {
     File input_bam
     String report_filename
 
-    String docker_tag = "malaria-samtools:1.4.1"
+    String docker_tag = "malaria-samtools@sha256:e6f69efb1481e737cea07ae9e365457761e52720e559b28432b8495cec800c63"
     Int num_cpu = 1
     Int memory = 2000
     String? lsf_group
@@ -639,7 +639,7 @@ task GatkCallableLoci {
     File input_bam_index
     String summary_filename
 
-    String docker_tag = "malaria-gatk3:3.7.0"
+    String docker_tag = "malaria-gatk3@sha256:11dcafb2c5b574c8313942874ec8449b536adcc37c00bad149f1ef1a45012a28"
     Int num_cpu = 1
     Int memory = 4000
     String? lsf_group

--- a/tasks/farm5/ShortReadAlignmentTasks.wdl
+++ b/tasks/farm5/ShortReadAlignmentTasks.wdl
@@ -260,10 +260,10 @@ task ReadAlignmentPostProcessing {
     set -e
     set -o pipefail
 
-    /bin/samtools view -bu ~{input_sam} |
-    /bin/samtools sort -n - |
-    /bin/samtools fixmate - - |
-    /bin/samtools sort - > ~{output_bam_basename}.bam
+    samtools view -bu ~{input_sam} |
+    samtools sort -n - |
+    samtools fixmate - - |
+    samtools sort - > ~{output_bam_basename}.bam
 
   }
 
@@ -548,7 +548,7 @@ task SamtoolsStats {
     set -e
     set -o pipefail
 
-    /bin/samtools stats -r ~{reference.ref_fasta} ~{input_file} > ~{report_filename}
+    samtools stats -r ~{reference.ref_fasta} ~{input_file} > ~{report_filename}
 
   }
 
@@ -583,7 +583,7 @@ task SamtoolsIdxStats {
     set -e
     set -o pipefail
 
-    /bin/samtools idxstats ~{input_bam} > ~{report_filename}
+    samtools idxstats ~{input_bam} > ~{report_filename}
 
   }
 
@@ -617,7 +617,7 @@ task SamtoolsFlagStat {
     set -e
     set -o pipefail
 
-    /bin/samtools flagstat ~{input_bam} > ~{report_filename}
+    samtools flagstat ~{input_bam} > ~{report_filename}
 
   }
 


### PR DESCRIPTION
Changes farm5 pipelines to use docker images (pulled from some remote repository, e.g. docker hub) in place of manually built singularity images (stored on the farm). Also adds a Dockerfile for iRODS import/batch processing dependencies. 