### PR TITLE
Allow for flexible columns in manifest for vector alignment genotyping pipeline

### DIFF
--- a/pipelines/import-short-read-lanelet-alignment-vector/farm5/ImportShortReadLaneletAlignment.wdl
+++ b/pipelines/import-short-read-lanelet-alignment-vector/farm5/ImportShortReadLaneletAlignment.wdl
@@ -22,9 +22,8 @@ import "../../../tasks/farm5/ShortReadAlignmentTasks.wdl" as AlignTasks
 
 workflow ImportShortReadLaneletAlignment {
   String pipeline_version = "1.0.0"
-  Int IDX_LANELET_INFO_SAMPLE_ID = 0
-  Int IDX_LANELET_INFO_IRODS_PATH = 1
-
+  
+  String LANELET_INFO_COLNAME_IRODS_PATH = "irods_path"
 
   input {
     String sample_id
@@ -34,10 +33,10 @@ workflow ImportShortReadLaneletAlignment {
     RunTimeSettings runTimeSettings
   }
 
-  Array[Array[String]] lanelet_infos = read_tsv(per_sample_manifest_file)
-  scatter (lanelet_info in lanelet_infos) {
+  Array[Object] lanelet_infos = read_objects(per_sample_manifest_file)
+  scatter (idx in range(length(lanelet_infos))) {
 
-    String irods_path = lanelet_info[IDX_LANELET_INFO_IRODS_PATH]
+    String irods_path = lanelet_infos[idx][LANELET_INFO_COLNAME_IRODS_PATH]
 
     call ImportTask.ImportIRODS as ImportIRODS {
       input:

--- a/tasks/farm5/ImportTasks.wdl
+++ b/tasks/farm5/ImportTasks.wdl
@@ -77,14 +77,14 @@ task BatchSplitUpInputFile {
   # Split the manifest into separate files
   for sample_id in sample_mf["sample_id"].unique():
       sample_mf[sample_mf["sample_id"] == sample_id].to_csv("{}_manifest.tsv".format(sample_id),
-                                                            header=False,
+                                                            header=True,
                                                             sep="\t",
                                                             index=False)
   CODE
   >>>
 
   runtime {
-    docker: docker_tag 
+    docker: docker_tag
     memory: memory
     cpu: num_cpu
     lsf_group: select_first([runTimeSettings.lsf_group, lsf_group, "pathdev"])
@@ -93,6 +93,46 @@ task BatchSplitUpInputFile {
 
   output {
       Array[File] per_sample_manifest_files = glob("*_manifest.tsv")
+  }
+
+}
+
+
+# Check that there are mandatory columns: sample_id, irods_path
+# Check that each lanelet row has the same sample ID
+task ValidatePerSampleManifestFile {
+  input {
+    File per_sample_manifest_file
+
+    String docker_tag = "sangerpathogens/malaria-irods@sha256:adadaf506ac1d99dfc9a0eb2d8f4cad4527e1a0d00fbf18d8864155ce16038d8"
+    Int num_cpu = 1
+    Int memory = 3000
+    String? lsf_group
+    String? lsf_queue
+    RunTimeSettings runTimeSettings
+  }
+
+  command <<<
+
+  python <<CODE
+  import pandas as pd
+
+  sample_mf = pd.read_csv("~{per_sample_manifest_file}", sep="\t")
+
+  assert 'sample_id' in sample_mf.columns, "sample_id is not in header"
+  assert 'irods_path' in sample_mf.columns, "irods_path is not in header"
+
+  assert sample_mf["sample_id"].nunique(dropna=True) == 1, "per_sample_manifest_file should contain only 1 sample under sample_id column"
+
+  CODE
+  >>>
+
+  runtime {
+    docker: docker_tag
+    memory: memory
+    cpu: num_cpu
+    lsf_group: select_first([runTimeSettings.lsf_group, lsf_group, "pathdev"])
+    lsf_queue: select_first([runTimeSettings.lsf_queue, lsf_queue, "normal"])
   }
 
 }


### PR DESCRIPTION
Addresses #70 

NB:  this will fail miniwdl validation.  But it passes womtool validation.  I suspect it's because miniwdl doesn't support read_objects() WDL function from WDL v1.0, but not 100% sure.  


https://github.com/malariagen/pipelines/blob/5d26c17c70a5edce00c0ad8a65beda841428ec87/pipelines/import-short-read-lanelet-alignment-vector/farm5/ImportShortReadLaneletAlignment.wdl#L36

The preferred approach is to get miniwdl to recognize the WDL as valid, whether that means to modify the WDL or miniwdl settings.  Another approach is to switch github actions to use womtool instead of miniwdl for validation.  However, womtool syntax validation is not nearly as thorough as miniwdl.