### PR TITLE
Add throttle_irods runtime attribute

### DIFF
--- a/tasks/farm5/ImportTasks.wdl
+++ b/tasks/farm5/ImportTasks.wdl
@@ -35,6 +35,7 @@ task ImportIRODS {
     cpu: num_cpu
     lsf_group: select_first([runTimeSettings.lsf_group, lsf_group, "pathdev"])
     lsf_queue: select_first([runTimeSettings.lsf_queue, lsf_queue, "normal"])
+    throttle_irods: true
   }
 
   output {


### PR DESCRIPTION
To avoid opening too many connections to iRODS simultaneously on the farm.