### PR TITLE
Updating gcp flavor of Vector pipelines to handle updates applied to farm5

### DIFF
--- a/pipelines/SNP-genotyping-vector/gcp/input_files/small/AV0148-C.json
+++ b/pipelines/SNP-genotyping-vector/gcp/input_files/small/AV0148-C.json
@@ -16,15 +16,6 @@
     "ref_pac": "gs://malariagen/references/Anopheles-gambiae-PEST_CHROMOSOMES_AgamP4/Anopheles-gambiae-PEST_CHROMOSOMES_AgamP4.fa.pac"
   },
   "SNPGenotyping.runTimeSettings": {
-    "preemptible_tries": 0,
-    "gatk_docker": "broadinstitute/gatk3:3.7-0",
-    "picard_docker": "us.gcr.io/broad-gotc-prod/malariagen/picard:2.9.2",
-    "bwa_docker": "us.gcr.io/broad-gotc-prod/malariagen/bwa:0.7.15",
-    "biobambam_docker": "us.gcr.io/broad-gotc-prod/malariagen/biobambam2:2.0.73",
-    "samtools_docker": "us.gcr.io/broad-gotc-prod/malariagen/samtools:1.4.1",
-    "vcftozarr_docker": "us.gcr.io/broad-gotc-prod/malariagen/samplevcftozarr:1.1",
-    "lftp_docker": "us.gcr.io/broad-gotc-prod/malariagen/lftp:1.0",
-    "select_variants_docker": "us.gcr.io/broad-gotc-prod/malariagen/sampleselectvariants:1.0",
-    "whatshap_docker": "us.gcr.io/broad-gotc-prod/malariagen/whatshap:1.0"
+    "preemptible_tries": 0
   }
 }

--- a/pipelines/phasing-vector/gcp/input_files/Ag1000Phase2_BurkinaFaso.json
+++ b/pipelines/phasing-vector/gcp/input_files/Ag1000Phase2_BurkinaFaso.json
@@ -698,18 +698,6 @@
     "ref_chr_lengths": "gs://malariagen/references/Anopheles-gambiae-PEST_CHROMOSOMES_AgamP4/Anopheles-gambiae-PEST_CHROMOSOMES_AgamP4.chr_lengths.txt"
   },
   "Phasing.runTimeSettings": {
-    "preemptible_tries": 0,
-    "gatk_docker": "broadinstitute/gatk3:3.7-0",
-    "picard_docker": "us.gcr.io/broad-gotc-prod/malariagen/picard:2.9.2",
-    "bwa_docker": "us.gcr.io/broad-gotc-prod/malariagen/bwa:0.7.15",
-    "biobambam_docker": "us.gcr.io/broad-gotc-prod/malariagen/biobambam2:2.0.73",
-    "cohortvcftozarr_docker": "us.gcr.io/broad-gotc-prod/malariagen/cohortvcftozarr:1.0",
-    "samtools_docker": "us.gcr.io/broad-gotc-prod/malariagen/samtools:1.4.1",
-    "bcftools_docker": "us.gcr.io/broad-gotc-prod/malariagen/bcftools:1.11",
-    "vcftozarr_docker": "us.gcr.io/broad-gotc-prod/malariagen/samplevcftozarr:1.1",
-    "lftp_docker": "us.gcr.io/broad-gotc-prod/malariagen/lftp:1.0",
-    "select_variants_docker": "us.gcr.io/broad-gotc-prod/malariagen/sampleselectvariants:1.0",
-    "whatshap_docker": "us.gcr.io/broad-gotc-prod/malariagen/whatshap:1.0",
-    "shapeit4_docker": "us.gcr.io/broad-gotc-prod/malariagen/shapeit4:4.1.3"
+    "preemptible_tries": 0
   }
 }

--- a/pipelines/phasing-vector/gcp/input_files/Ag1000Phase2_BurkinaFaso_Small.json
+++ b/pipelines/phasing-vector/gcp/input_files/Ag1000Phase2_BurkinaFaso_Small.json
@@ -50,18 +50,6 @@
     "ref_chr_lengths": "gs://malariagen/references/Anopheles-gambiae-PEST_CHROMOSOMES_AgamP4/Anopheles-gambiae-PEST_CHROMOSOMES_AgamP4.chr_lengths.txt"
   },
   "Phasing.runTimeSettings": {
-    "preemptible_tries": 0,
-    "gatk_docker": "broadinstitute/gatk3:3.7-0",
-    "picard_docker": "us.gcr.io/broad-gotc-prod/malariagen/picard:2.9.2",
-    "bwa_docker": "us.gcr.io/broad-gotc-prod/malariagen/bwa:0.7.15",
-    "biobambam_docker": "us.gcr.io/broad-gotc-prod/malariagen/biobambam2:2.0.73",
-    "cohortvcftozarr_docker": "us.gcr.io/broad-gotc-prod/malariagen/cohortvcftozarr:1.0",
-    "samtools_docker": "us.gcr.io/broad-gotc-prod/malariagen/samtools:1.4.1",
-    "bcftools_docker": "us.gcr.io/broad-gotc-prod/malariagen/bcftools:1.11",
-    "vcftozarr_docker": "us.gcr.io/broad-gotc-prod/malariagen/samplevcftozarr:1.1",
-    "lftp_docker": "us.gcr.io/broad-gotc-prod/malariagen/lftp:1.0",
-    "select_variants_docker": "us.gcr.io/broad-gotc-prod/malariagen/sampleselectvariants:1.0",
-    "whatshap_docker": "us.gcr.io/broad-gotc-prod/malariagen/whatshap:1.0",
-    "shapeit4_docker": "us.gcr.io/broad-gotc-prod/malariagen/shapeit4:4.1.3"
+    "preemptible_tries": 0
   }
 }

--- a/pipelines/phasing-vector/gcp/input_files/small/ReadBackedPhasing_AV0079-C.json
+++ b/pipelines/phasing-vector/gcp/input_files/small/ReadBackedPhasing_AV0079-C.json
@@ -19,17 +19,6 @@
     "ref_chr_lengths": "gs://malariagen/references/Anopheles-gambiae-PEST_CHROMOSOMES_AgamP4/Anopheles-gambiae-PEST_CHROMOSOMES_AgamP4.chr_lengths.txt"
   },
   "ReadBackedPhasing.runTimeSettings": {
-    "preemptible_tries": 0,
-    "gatk_docker": "broadinstitute/gatk3:3.7-0",
-    "picard_docker": "us.gcr.io/broad-gotc-prod/malariagen/picard:2.9.2",
-    "bwa_docker": "us.gcr.io/broad-gotc-prod/malariagen/bwa:0.7.15",
-    "biobambam_docker": "us.gcr.io/broad-gotc-prod/malariagen/biobambam2:2.0.73",
-    "samtools_docker": "us.gcr.io/broad-gotc-prod/malariagen/samtools:1.4.1",
-    "bcftools_docker": "us.gcr.io/broad-gotc-prod/malariagen/bcftools:1.11",
-    "vcftozarr_docker": "us.gcr.io/broad-gotc-prod/malariagen/samplevcftozarr:1.1",
-    "lftp_docker": "us.gcr.io/broad-gotc-prod/malariagen/lftp:1.0",
-    "select_variants_docker": "us.gcr.io/broad-gotc-prod/malariagen/sampleselectvariants:1.0",
-    "whatshap_docker": "us.gcr.io/broad-gotc-prod/malariagen/whatshap:1.0",
-    "shapeit4_docker": "us.gcr.io/broad-gotc-prod/malariagen/shapeit4:4.1.3"
+    "preemptible_tries": 0
   }
 }

--- a/pipelines/phasing-vector/gcp/input_files/small/ReadBackedPhasing_AV0148-C.json
+++ b/pipelines/phasing-vector/gcp/input_files/small/ReadBackedPhasing_AV0148-C.json
@@ -19,17 +19,6 @@
     "ref_chr_lengths": "gs://malariagen/references/Anopheles-gambiae-PEST_CHROMOSOMES_AgamP4/Anopheles-gambiae-PEST_CHROMOSOMES_AgamP4.chr_lengths.txt"
   },
   "ReadBackedPhasing.runTimeSettings": {
-    "preemptible_tries": 0,
-    "gatk_docker": "broadinstitute/gatk3:3.7-0",
-    "picard_docker": "us.gcr.io/broad-gotc-prod/malariagen/picard:2.9.2",
-    "bwa_docker": "us.gcr.io/broad-gotc-prod/malariagen/bwa:0.7.15",
-    "biobambam_docker": "us.gcr.io/broad-gotc-prod/malariagen/biobambam2:2.0.73",
-    "samtools_docker": "us.gcr.io/broad-gotc-prod/malariagen/samtools:1.4.1",
-    "bcftools_docker": "us.gcr.io/broad-gotc-prod/malariagen/bcftools:1.11",
-    "vcftozarr_docker": "us.gcr.io/broad-gotc-prod/malariagen/samplevcftozarr:1.1",
-    "lftp_docker": "us.gcr.io/broad-gotc-prod/malariagen/lftp:1.0",
-    "select_variants_docker": "us.gcr.io/broad-gotc-prod/malariagen/sampleselectvariants:1.0",
-    "whatshap_docker": "us.gcr.io/broad-gotc-prod/malariagen/whatshap:1.0",
-    "shapeit4_docker": "us.gcr.io/broad-gotc-prod/malariagen/shapeit4:4.1.3"
+    "preemptible_tries": 0
   }
 }

--- a/pipelines/phasing-vector/gcp/input_files/small/StatisticalPhasing_Small.json
+++ b/pipelines/phasing-vector/gcp/input_files/small/StatisticalPhasing_Small.json
@@ -21,17 +21,6 @@
     "ref_pac": "gs://malariagen/references/Anopheles-gambiae-PEST_CHROMOSOMES_AgamP4/Anopheles-gambiae-PEST_CHROMOSOMES_AgamP4.fa.pac"
   },
   "StatisticalPhasing.runTimeSettings": {
-    "preemptible_tries": 0,
-    "gatk_docker": "broadinstitute/gatk3:3.7-0",
-    "picard_docker": "us.gcr.io/broad-gotc-prod/malariagen/picard:2.9.2",
-    "bwa_docker": "us.gcr.io/broad-gotc-prod/malariagen/bwa:0.7.15",
-    "biobambam_docker": "us.gcr.io/broad-gotc-prod/malariagen/biobambam2:2.0.73",
-    "samtools_docker": "us.gcr.io/broad-gotc-prod/malariagen/samtools:1.4.1",
-    "bcftools_docker": "us.gcr.io/broad-gotc-prod/malariagen/bcftools:1.11",
-    "vcftozarr_docker": "us.gcr.io/broad-gotc-prod/malariagen/samplevcftozarr:1.1",
-    "lftp_docker": "us.gcr.io/broad-gotc-prod/malariagen/lftp:1.0",
-    "select_variants_docker": "us.gcr.io/broad-gotc-prod/malariagen/sampleselectvariants:1.0",
-    "whatshap_docker": "us.gcr.io/broad-gotc-prod/malariagen/whatshap:1.0",
-    "shapeit4_docker": "us.gcr.io/broad-gotc-prod/malariagen/shapeit4:4.1.3"
+    "preemptible_tries": 0
   }
 }

--- a/pipelines/phasing-vector/gcp/input_files/validation/Phasing_Validation.json
+++ b/pipelines/phasing-vector/gcp/input_files/validation/Phasing_Validation.json
@@ -44,17 +44,6 @@
     "ref_chr_lengths": "gs://malariagen/references/Anopheles-gambiae-PEST_CHROMOSOMES_AgamP4/Anopheles-gambiae-PEST_CHROMOSOMES_AgamP4.chr_lengths.txt"
   },
   "Phasing.runTimeSettings": {
-    "preemptible_tries": 0,
-    "gatk_docker": "broadinstitute/gatk3:3.7-0",
-    "picard_docker": "us.gcr.io/broad-gotc-prod/malariagen/picard:2.9.2",
-    "bwa_docker": "us.gcr.io/broad-gotc-prod/malariagen/bwa:0.7.15",
-    "biobambam_docker": "us.gcr.io/broad-gotc-prod/malariagen/biobambam2:2.0.73",
-    "samtools_docker": "us.gcr.io/broad-gotc-prod/malariagen/samtools:1.4.1",
-    "bcftools_docker": "us.gcr.io/broad-gotc-prod/malariagen/bcftools:1.11",
-    "vcftozarr_docker": "us.gcr.io/broad-gotc-prod/malariagen/samplevcftozarr:1.1",
-    "lftp_docker": "us.gcr.io/broad-gotc-prod/malariagen/lftp:1.0",
-    "select_variants_docker": "us.gcr.io/broad-gotc-prod/malariagen/sampleselectvariants:1.0",
-    "whatshap_docker": "us.gcr.io/broad-gotc-prod/malariagen/whatshap:1.0",
-    "shapeit4_docker": "us.gcr.io/broad-gotc-prod/malariagen/shapeit4:4.1.3"
+    "preemptible_tries": 0
   }
 }

--- a/pipelines/phasing-vector/gcp/input_files/validation/ReadBackedPhasing_AA0052-C.json
+++ b/pipelines/phasing-vector/gcp/input_files/validation/ReadBackedPhasing_AA0052-C.json
@@ -19,17 +19,6 @@
     "ref_chr_lengths": "gs://malariagen/references/Anopheles-gambiae-PEST_CHROMOSOMES_AgamP4/Anopheles-gambiae-PEST_CHROMOSOMES_AgamP4.chr_lengths.txt"
   },
   "ReadBackedPhasing.runTimeSettings": {
-    "preemptible_tries": 0,
-    "gatk_docker": "broadinstitute/gatk3:3.7-0",
-    "picard_docker": "us.gcr.io/broad-gotc-prod/malariagen/picard:2.9.2",
-    "bwa_docker": "us.gcr.io/broad-gotc-prod/malariagen/bwa:0.7.15",
-    "biobambam_docker": "us.gcr.io/broad-gotc-prod/malariagen/biobambam2:2.0.73",
-    "samtools_docker": "us.gcr.io/broad-gotc-prod/malariagen/samtools:1.4.1",
-    "bcftools_docker": "us.gcr.io/broad-gotc-prod/malariagen/bcftools:1.11",
-    "vcftozarr_docker": "us.gcr.io/broad-gotc-prod/malariagen/samplevcftozarr:1.1",
-    "lftp_docker": "us.gcr.io/broad-gotc-prod/malariagen/lftp:1.0",
-    "select_variants_docker": "us.gcr.io/broad-gotc-prod/malariagen/sampleselectvariants:1.0",
-    "whatshap_docker": "us.gcr.io/broad-gotc-prod/malariagen/whatshap:1.0",
-    "shapeit4_docker": "us.gcr.io/broad-gotc-prod/malariagen/shapeit4:4.1.3"
+    "preemptible_tries": 0
   }
 }

--- a/pipelines/phasing-vector/gcp/input_files/validation/ReadBackedPhasing_AB0252-C.json
+++ b/pipelines/phasing-vector/gcp/input_files/validation/ReadBackedPhasing_AB0252-C.json
@@ -19,17 +19,6 @@
     "ref_chr_lengths": "gs://malariagen/references/Anopheles-gambiae-PEST_CHROMOSOMES_AgamP4/Anopheles-gambiae-PEST_CHROMOSOMES_AgamP4.chr_lengths.txt"
   },
   "ReadBackedPhasing.runTimeSettings": {
-    "preemptible_tries": 0,
-    "gatk_docker": "broadinstitute/gatk3:3.7-0",
-    "picard_docker": "us.gcr.io/broad-gotc-prod/malariagen/picard:2.9.2",
-    "bwa_docker": "us.gcr.io/broad-gotc-prod/malariagen/bwa:0.7.15",
-    "biobambam_docker": "us.gcr.io/broad-gotc-prod/malariagen/biobambam2:2.0.73",
-    "samtools_docker": "us.gcr.io/broad-gotc-prod/malariagen/samtools:1.4.1",
-    "bcftools_docker": "us.gcr.io/broad-gotc-prod/malariagen/bcftools:1.11",
-    "vcftozarr_docker": "us.gcr.io/broad-gotc-prod/malariagen/samplevcftozarr:1.1",
-    "lftp_docker": "us.gcr.io/broad-gotc-prod/malariagen/lftp:1.0",
-    "select_variants_docker": "us.gcr.io/broad-gotc-prod/malariagen/sampleselectvariants:1.0",
-    "whatshap_docker": "us.gcr.io/broad-gotc-prod/malariagen/whatshap:1.0",
-    "shapeit4_docker": "us.gcr.io/broad-gotc-prod/malariagen/shapeit4:4.1.3"
+    "preemptible_tries": 0
   }
 }

--- a/pipelines/phasing-vector/gcp/input_files/validation/ReadBackedPhasing_AC0010-C.json
+++ b/pipelines/phasing-vector/gcp/input_files/validation/ReadBackedPhasing_AC0010-C.json
@@ -19,17 +19,6 @@
     "ref_chr_lengths": "gs://malariagen/references/Anopheles-gambiae-PEST_CHROMOSOMES_AgamP4/Anopheles-gambiae-PEST_CHROMOSOMES_AgamP4.chr_lengths.txt"
   },
   "ReadBackedPhasing.runTimeSettings": {
-    "preemptible_tries": 0,
-    "gatk_docker": "broadinstitute/gatk3:3.7-0",
-    "picard_docker": "us.gcr.io/broad-gotc-prod/malariagen/picard:2.9.2",
-    "bwa_docker": "us.gcr.io/broad-gotc-prod/malariagen/bwa:0.7.15",
-    "biobambam_docker": "us.gcr.io/broad-gotc-prod/malariagen/biobambam2:2.0.73",
-    "samtools_docker": "us.gcr.io/broad-gotc-prod/malariagen/samtools:1.4.1",
-    "bcftools_docker": "us.gcr.io/broad-gotc-prod/malariagen/bcftools:1.11",
-    "vcftozarr_docker": "us.gcr.io/broad-gotc-prod/malariagen/samplevcftozarr:1.1",
-    "lftp_docker": "us.gcr.io/broad-gotc-prod/malariagen/lftp:1.0",
-    "select_variants_docker": "us.gcr.io/broad-gotc-prod/malariagen/sampleselectvariants:1.0",
-    "whatshap_docker": "us.gcr.io/broad-gotc-prod/malariagen/whatshap:1.0",
-    "shapeit4_docker": "us.gcr.io/broad-gotc-prod/malariagen/shapeit4:4.1.3"
+    "preemptible_tries": 0
   }
 }

--- a/pipelines/phasing-vector/gcp/input_files/validation/ReadBackedPhasing_BL0358-C.json
+++ b/pipelines/phasing-vector/gcp/input_files/validation/ReadBackedPhasing_BL0358-C.json
@@ -19,17 +19,6 @@
     "ref_chr_lengths": "gs://malariagen/references/Anopheles-gambiae-PEST_CHROMOSOMES_AgamP4/Anopheles-gambiae-PEST_CHROMOSOMES_AgamP4.chr_lengths.txt"
   },
   "ReadBackedPhasing.runTimeSettings": {
-    "preemptible_tries": 0,
-    "gatk_docker": "broadinstitute/gatk3:3.7-0",
-    "picard_docker": "us.gcr.io/broad-gotc-prod/malariagen/picard:2.9.2",
-    "bwa_docker": "us.gcr.io/broad-gotc-prod/malariagen/bwa:0.7.15",
-    "biobambam_docker": "us.gcr.io/broad-gotc-prod/malariagen/biobambam2:2.0.73",
-    "samtools_docker": "us.gcr.io/broad-gotc-prod/malariagen/samtools:1.4.1",
-    "bcftools_docker": "us.gcr.io/broad-gotc-prod/malariagen/bcftools:1.11",
-    "vcftozarr_docker": "us.gcr.io/broad-gotc-prod/malariagen/samplevcftozarr:1.1",
-    "lftp_docker": "us.gcr.io/broad-gotc-prod/malariagen/lftp:1.0",
-    "select_variants_docker": "us.gcr.io/broad-gotc-prod/malariagen/sampleselectvariants:1.0",
-    "whatshap_docker": "us.gcr.io/broad-gotc-prod/malariagen/whatshap:1.0",
-    "shapeit4_docker": "us.gcr.io/broad-gotc-prod/malariagen/shapeit4:4.1.3"
+    "preemptible_tries": 0
   }
 }

--- a/pipelines/phasing-vector/gcp/input_files/validation/StatisticalPhasing_Validation.json
+++ b/pipelines/phasing-vector/gcp/input_files/validation/StatisticalPhasing_Validation.json
@@ -25,17 +25,6 @@
     "ref_pac": "gs://malariagen/references/Anopheles-gambiae-PEST_CHROMOSOMES_AgamP4/Anopheles-gambiae-PEST_CHROMOSOMES_AgamP4.fa.pac"
   },
   "StatisticalPhasing.runTimeSettings": {
-    "preemptible_tries": 0,
-    "gatk_docker": "broadinstitute/gatk3:3.7-0",
-    "picard_docker": "us.gcr.io/broad-gotc-prod/malariagen/picard:2.9.2",
-    "bwa_docker": "us.gcr.io/broad-gotc-prod/malariagen/bwa:0.7.15",
-    "biobambam_docker": "us.gcr.io/broad-gotc-prod/malariagen/biobambam2:2.0.73",
-    "samtools_docker": "us.gcr.io/broad-gotc-prod/malariagen/samtools:1.4.1",
-    "bcftools_docker": "us.gcr.io/broad-gotc-prod/malariagen/bcftools:1.11",
-    "vcftozarr_docker": "us.gcr.io/broad-gotc-prod/malariagen/samplevcftozarr:1.1",
-    "lftp_docker": "us.gcr.io/broad-gotc-prod/malariagen/lftp:1.0",
-    "select_variants_docker": "us.gcr.io/broad-gotc-prod/malariagen/sampleselectvariants:1.0",
-    "whatshap_docker": "us.gcr.io/broad-gotc-prod/malariagen/whatshap:1.0",
-    "shapeit4_docker": "us.gcr.io/broad-gotc-prod/malariagen/shapeit4:4.1.3"
+    "preemptible_tries": 0
   }
 }

--- a/pipelines/short-read-alignment-and-genotyping-vector/gcp/input_files/small/AV0079-C.json
+++ b/pipelines/short-read-alignment-and-genotyping-vector/gcp/input_files/small/AV0079-C.json
@@ -14,17 +14,6 @@
     "ref_pac": "gs://broad-gotc-dev-storage/malariaGEN/references/Anopheles-gambiae-PEST_CHROMOSOMES_AgamP4/Anopheles-gambiae-PEST_CHROMOSOMES_AgamP4.fa.pac"
   },
   "ShortReadAlignmentAndGenotyping.runTimeSettings": {
-    "preemptible_tries": 0,
-    "gatk_docker": "broadinstitute/gatk3:3.7-0",
-    "picard_docker": "us.gcr.io/broad-gotc-prod/malariagen/picard:2.9.2",
-    "bwa_docker": "us.gcr.io/broad-gotc-prod/malariagen/bwa:0.7.15",
-    "biobambam_docker": "us.gcr.io/broad-gotc-prod/malariagen/biobambam2:2.0.73",
-    "samtools_docker": "us.gcr.io/broad-gotc-prod/malariagen/samtools:1.4.1",
-    "bcftools_docker": "us.gcr.io/broad-gotc-prod/malariagen/bcftools:1.11",
-    "vcftozarr_docker": "us.gcr.io/broad-gotc-prod/malariagen/samplevcftozarr:1.1",
-    "lftp_docker": "us.gcr.io/broad-gotc-prod/malariagen/lftp:1.0",
-    "select_variants_docker": "us.gcr.io/broad-gotc-prod/malariagen/sampleselectvariants:1.0",
-    "whatshap_docker": "us.gcr.io/broad-gotc-prod/malariagen/whatshap:1.0",
-    "shapeit4_docker": "us.gcr.io/broad-gotc-prod/malariagen/shapeit4:4.1.3"
+    "preemptible_tries": 0
   }
 }

--- a/pipelines/short-read-alignment-and-genotyping-vector/gcp/input_files/small/AV0148-C.json
+++ b/pipelines/short-read-alignment-and-genotyping-vector/gcp/input_files/small/AV0148-C.json
@@ -14,17 +14,6 @@
     "ref_pac": "gs://malariagen/references/Anopheles-gambiae-PEST_CHROMOSOMES_AgamP4/Anopheles-gambiae-PEST_CHROMOSOMES_AgamP4.fa.pac"
   },
   "ShortReadAlignmentAndGenotyping.runTimeSettings": {
-    "preemptible_tries": 0,
-    "gatk_docker": "broadinstitute/gatk3:3.7-0",
-    "picard_docker": "us.gcr.io/broad-gotc-prod/malariagen/picard:2.9.2",
-    "bwa_docker": "us.gcr.io/broad-gotc-prod/malariagen/bwa:0.7.15",
-    "biobambam_docker": "us.gcr.io/broad-gotc-prod/malariagen/biobambam2:2.0.73",
-    "samtools_docker": "us.gcr.io/broad-gotc-prod/malariagen/samtools:1.4.1",
-    "bcftools_docker": "us.gcr.io/broad-gotc-prod/malariagen/bcftools:1.11",
-    "vcftozarr_docker": "us.gcr.io/broad-gotc-prod/malariagen/samplevcftozarr:1.1",
-    "lftp_docker": "us.gcr.io/broad-gotc-prod/malariagen/lftp:1.0",
-    "select_variants_docker": "us.gcr.io/broad-gotc-prod/malariagen/sampleselectvariants:1.0",
-    "whatshap_docker": "us.gcr.io/broad-gotc-prod/malariagen/whatshap:1.0",
-    "shapeit4_docker": "us.gcr.io/broad-gotc-prod/malariagen/shapeit4:4.1.3"
+    "preemptible_tries": 0
   }
 }

--- a/pipelines/short-read-alignment-and-genotyping-vector/gcp/input_files/validation/AA0052-C.json
+++ b/pipelines/short-read-alignment-and-genotyping-vector/gcp/input_files/validation/AA0052-C.json
@@ -14,17 +14,6 @@
     "ref_pac": "gs://malariagen/references/Anopheles-gambiae-PEST_CHROMOSOMES_AgamP4/Anopheles-gambiae-PEST_CHROMOSOMES_AgamP4.fa.pac"
   },
   "ShortReadAlignmentAndGenotyping.runTimeSettings": {
-    "preemptible_tries": 0,
-    "gatk_docker": "broadinstitute/gatk3:3.7-0",
-    "picard_docker": "us.gcr.io/broad-gotc-prod/malariagen/picard:2.9.2",
-    "bwa_docker": "us.gcr.io/broad-gotc-prod/malariagen/bwa:0.7.15",
-    "biobambam_docker": "us.gcr.io/broad-gotc-prod/malariagen/biobambam2:2.0.73",
-    "samtools_docker": "us.gcr.io/broad-gotc-prod/malariagen/samtools:1.4.1",
-    "bcftools_docker": "us.gcr.io/broad-gotc-prod/malariagen/bcftools:1.11",
-    "vcftozarr_docker": "us.gcr.io/broad-gotc-prod/malariagen/samplevcftozarr:1.1",
-    "lftp_docker": "us.gcr.io/broad-gotc-prod/malariagen/lftp:1.0",
-    "select_variants_docker": "us.gcr.io/broad-gotc-prod/malariagen/sampleselectvariants:1.0",
-    "whatshap_docker": "us.gcr.io/broad-gotc-prod/malariagen/whatshap:1.0",
-    "shapeit4_docker": "us.gcr.io/broad-gotc-prod/malariagen/shapeit4:4.1.3"
+    "preemptible_tries": 0
   }
 }

--- a/pipelines/short-read-alignment-and-genotyping-vector/gcp/input_files/validation/AB0252-C.json
+++ b/pipelines/short-read-alignment-and-genotyping-vector/gcp/input_files/validation/AB0252-C.json
@@ -14,17 +14,6 @@
     "ref_pac": "gs://malariagen/references/Anopheles-gambiae-PEST_CHROMOSOMES_AgamP4/Anopheles-gambiae-PEST_CHROMOSOMES_AgamP4.fa.pac"
   },
   "ShortReadAlignmentAndGenotyping.runTimeSettings": {
-    "preemptible_tries": 0,
-    "gatk_docker": "broadinstitute/gatk3:3.7-0",
-    "picard_docker": "us.gcr.io/broad-gotc-prod/malariagen/picard:2.9.2",
-    "bwa_docker": "us.gcr.io/broad-gotc-prod/malariagen/bwa:0.7.15",
-    "biobambam_docker": "us.gcr.io/broad-gotc-prod/malariagen/biobambam2:2.0.73",
-    "samtools_docker": "us.gcr.io/broad-gotc-prod/malariagen/samtools:1.4.1",
-    "bcftools_docker": "us.gcr.io/broad-gotc-prod/malariagen/bcftools:1.11",
-    "vcftozarr_docker": "us.gcr.io/broad-gotc-prod/malariagen/samplevcftozarr:1.1",
-    "lftp_docker": "us.gcr.io/broad-gotc-prod/malariagen/lftp:1.0",
-    "select_variants_docker": "us.gcr.io/broad-gotc-prod/malariagen/sampleselectvariants:1.0",
-    "whatshap_docker": "us.gcr.io/broad-gotc-prod/malariagen/whatshap:1.0",
-    "shapeit4_docker": "us.gcr.io/broad-gotc-prod/malariagen/shapeit4:4.1.3"
+    "preemptible_tries": 0
   }
 }

--- a/pipelines/short-read-alignment-and-genotyping-vector/gcp/input_files/validation/AC0010-C.json
+++ b/pipelines/short-read-alignment-and-genotyping-vector/gcp/input_files/validation/AC0010-C.json
@@ -14,17 +14,6 @@
     "ref_pac": "gs://malariagen/references/Anopheles-gambiae-PEST_CHROMOSOMES_AgamP4/Anopheles-gambiae-PEST_CHROMOSOMES_AgamP4.fa.pac"
   },
   "ShortReadAlignmentAndGenotyping.runTimeSettings": {
-    "preemptible_tries": 0,
-    "gatk_docker": "broadinstitute/gatk3:3.7-0",
-    "picard_docker": "us.gcr.io/broad-gotc-prod/malariagen/picard:2.9.2",
-    "bwa_docker": "us.gcr.io/broad-gotc-prod/malariagen/bwa:0.7.15",
-    "biobambam_docker": "us.gcr.io/broad-gotc-prod/malariagen/biobambam2:2.0.73",
-    "samtools_docker": "us.gcr.io/broad-gotc-prod/malariagen/samtools:1.4.1",
-    "bcftools_docker": "us.gcr.io/broad-gotc-prod/malariagen/bcftools:1.11",
-    "vcftozarr_docker": "us.gcr.io/broad-gotc-prod/malariagen/samplevcftozarr:1.1",
-    "lftp_docker": "us.gcr.io/broad-gotc-prod/malariagen/lftp:1.0",
-    "select_variants_docker": "us.gcr.io/broad-gotc-prod/malariagen/sampleselectvariants:1.0",
-    "whatshap_docker": "us.gcr.io/broad-gotc-prod/malariagen/whatshap:1.0",
-    "shapeit4_docker": "us.gcr.io/broad-gotc-prod/malariagen/shapeit4:4.1.3"
+    "preemptible_tries": 0
   }
 }

--- a/pipelines/short-read-alignment-and-genotyping-vector/gcp/input_files/validation/AJ0037-C.json
+++ b/pipelines/short-read-alignment-and-genotyping-vector/gcp/input_files/validation/AJ0037-C.json
@@ -14,17 +14,6 @@
     "ref_pac": "gs://malariagen/references/Anopheles-gambiae-PEST_CHROMOSOMES_AgamP4/Anopheles-gambiae-PEST_CHROMOSOMES_AgamP4.fa.pac"
   },
   "ShortReadAlignmentAndGenotyping.runTimeSettings": {
-    "preemptible_tries": 0,
-    "gatk_docker": "broadinstitute/gatk3:3.7-0",
-    "picard_docker": "us.gcr.io/broad-gotc-prod/malariagen/picard:2.9.2",
-    "bwa_docker": "us.gcr.io/broad-gotc-prod/malariagen/bwa:0.7.15",
-    "biobambam_docker": "us.gcr.io/broad-gotc-prod/malariagen/biobambam2:2.0.73",
-    "samtools_docker": "us.gcr.io/broad-gotc-prod/malariagen/samtools:1.4.1",
-    "bcftools_docker": "us.gcr.io/broad-gotc-prod/malariagen/bcftools:1.11",
-    "vcftozarr_docker": "us.gcr.io/broad-gotc-prod/malariagen/samplevcftozarr:1.1",
-    "lftp_docker": "us.gcr.io/broad-gotc-prod/malariagen/lftp:1.0",
-    "select_variants_docker": "us.gcr.io/broad-gotc-prod/malariagen/sampleselectvariants:1.0",
-    "whatshap_docker": "us.gcr.io/broad-gotc-prod/malariagen/whatshap:1.0",
-    "shapeit4_docker": "us.gcr.io/broad-gotc-prod/malariagen/shapeit4:4.1.3"
+    "preemptible_tries": 0
   }
 }

--- a/pipelines/short-read-alignment-and-genotyping-vector/gcp/input_files/validation/AN0131-C.json
+++ b/pipelines/short-read-alignment-and-genotyping-vector/gcp/input_files/validation/AN0131-C.json
@@ -14,17 +14,6 @@
     "ref_pac": "gs://malariagen/references/Anopheles-gambiae-PEST_CHROMOSOMES_AgamP4/Anopheles-gambiae-PEST_CHROMOSOMES_AgamP4.fa.pac"
   },
   "ShortReadAlignmentAndGenotyping.runTimeSettings": {
-    "preemptible_tries": 0,
-    "gatk_docker": "broadinstitute/gatk3:3.7-0",
-    "picard_docker": "us.gcr.io/broad-gotc-prod/malariagen/picard:2.9.2",
-    "bwa_docker": "us.gcr.io/broad-gotc-prod/malariagen/bwa:0.7.15",
-    "biobambam_docker": "us.gcr.io/broad-gotc-prod/malariagen/biobambam2:2.0.73",
-    "samtools_docker": "us.gcr.io/broad-gotc-prod/malariagen/samtools:1.4.1",
-    "bcftools_docker": "us.gcr.io/broad-gotc-prod/malariagen/bcftools:1.11",
-    "vcftozarr_docker": "us.gcr.io/broad-gotc-prod/malariagen/samplevcftozarr:1.1",
-    "lftp_docker": "us.gcr.io/broad-gotc-prod/malariagen/lftp:1.0",
-    "select_variants_docker": "us.gcr.io/broad-gotc-prod/malariagen/sampleselectvariants:1.0",
-    "whatshap_docker": "us.gcr.io/broad-gotc-prod/malariagen/whatshap:1.0",
-    "shapeit4_docker": "us.gcr.io/broad-gotc-prod/malariagen/shapeit4:4.1.3"
+    "preemptible_tries": 0
   }
 }

--- a/pipelines/short-read-alignment-and-genotyping-vector/gcp/input_files/validation/AN0280-Cx.json
+++ b/pipelines/short-read-alignment-and-genotyping-vector/gcp/input_files/validation/AN0280-Cx.json
@@ -14,17 +14,6 @@
     "ref_pac": "gs://malariagen/references/Anopheles-gambiae-PEST_CHROMOSOMES_AgamP4/Anopheles-gambiae-PEST_CHROMOSOMES_AgamP4.fa.pac"
   },
   "ShortReadAlignmentAndGenotyping.runTimeSettings": {
-    "preemptible_tries": 0,
-    "gatk_docker": "broadinstitute/gatk3:3.7-0",
-    "picard_docker": "us.gcr.io/broad-gotc-prod/malariagen/picard:2.9.2",
-    "bwa_docker": "us.gcr.io/broad-gotc-prod/malariagen/bwa:0.7.15",
-    "biobambam_docker": "us.gcr.io/broad-gotc-prod/malariagen/biobambam2:2.0.73",
-    "samtools_docker": "us.gcr.io/broad-gotc-prod/malariagen/samtools:1.4.1",
-    "bcftools_docker": "us.gcr.io/broad-gotc-prod/malariagen/bcftools:1.11",
-    "vcftozarr_docker": "us.gcr.io/broad-gotc-prod/malariagen/samplevcftozarr:1.1",
-    "lftp_docker": "us.gcr.io/broad-gotc-prod/malariagen/lftp:1.0",
-    "select_variants_docker": "us.gcr.io/broad-gotc-prod/malariagen/sampleselectvariants:1.0",
-    "whatshap_docker": "us.gcr.io/broad-gotc-prod/malariagen/whatshap:1.0",
-    "shapeit4_docker": "us.gcr.io/broad-gotc-prod/malariagen/shapeit4:4.1.3"
+    "preemptible_tries": 0
   }
 }

--- a/pipelines/short-read-alignment-and-genotyping-vector/gcp/input_files/validation/AN0326-C.json
+++ b/pipelines/short-read-alignment-and-genotyping-vector/gcp/input_files/validation/AN0326-C.json
@@ -14,17 +14,6 @@
     "ref_pac": "gs://malariagen/references/Anopheles-gambiae-PEST_CHROMOSOMES_AgamP4/Anopheles-gambiae-PEST_CHROMOSOMES_AgamP4.fa.pac"
   },
   "ShortReadAlignmentAndGenotyping.runTimeSettings": {
-    "preemptible_tries": 0,
-    "gatk_docker": "broadinstitute/gatk3:3.7-0",
-    "picard_docker": "us.gcr.io/broad-gotc-prod/malariagen/picard:2.9.2",
-    "bwa_docker": "us.gcr.io/broad-gotc-prod/malariagen/bwa:0.7.15",
-    "biobambam_docker": "us.gcr.io/broad-gotc-prod/malariagen/biobambam2:2.0.73",
-    "samtools_docker": "us.gcr.io/broad-gotc-prod/malariagen/samtools:1.4.1",
-    "bcftools_docker": "us.gcr.io/broad-gotc-prod/malariagen/bcftools:1.11",
-    "vcftozarr_docker": "us.gcr.io/broad-gotc-prod/malariagen/samplevcftozarr:1.1",
-    "lftp_docker": "us.gcr.io/broad-gotc-prod/malariagen/lftp:1.0",
-    "select_variants_docker": "us.gcr.io/broad-gotc-prod/malariagen/sampleselectvariants:1.0",
-    "whatshap_docker": "us.gcr.io/broad-gotc-prod/malariagen/whatshap:1.0",
-    "shapeit4_docker": "us.gcr.io/broad-gotc-prod/malariagen/shapeit4:4.1.3"
+    "preemptible_tries": 0
   }
 }

--- a/pipelines/short-read-alignment-and-genotyping-vector/gcp/input_files/validation/AR0078-C.json
+++ b/pipelines/short-read-alignment-and-genotyping-vector/gcp/input_files/validation/AR0078-C.json
@@ -14,17 +14,6 @@
     "ref_pac": "gs://malariagen/references/Anopheles-gambiae-PEST_CHROMOSOMES_AgamP4/Anopheles-gambiae-PEST_CHROMOSOMES_AgamP4.fa.pac"
   },
   "ShortReadAlignmentAndGenotyping.runTimeSettings": {
-    "preemptible_tries": 0,
-    "gatk_docker": "broadinstitute/gatk3:3.7-0",
-    "picard_docker": "us.gcr.io/broad-gotc-prod/malariagen/picard:2.9.2",
-    "bwa_docker": "us.gcr.io/broad-gotc-prod/malariagen/bwa:0.7.15",
-    "biobambam_docker": "us.gcr.io/broad-gotc-prod/malariagen/biobambam2:2.0.73",
-    "samtools_docker": "us.gcr.io/broad-gotc-prod/malariagen/samtools:1.4.1",
-    "bcftools_docker": "us.gcr.io/broad-gotc-prod/malariagen/bcftools:1.11",
-    "vcftozarr_docker": "us.gcr.io/broad-gotc-prod/malariagen/samplevcftozarr:1.1",
-    "lftp_docker": "us.gcr.io/broad-gotc-prod/malariagen/lftp:1.0",
-    "select_variants_docker": "us.gcr.io/broad-gotc-prod/malariagen/sampleselectvariants:1.0",
-    "whatshap_docker": "us.gcr.io/broad-gotc-prod/malariagen/whatshap:1.0",
-    "shapeit4_docker": "us.gcr.io/broad-gotc-prod/malariagen/shapeit4:4.1.3"
+    "preemptible_tries": 0
   }
 }

--- a/pipelines/short-read-alignment-and-genotyping-vector/gcp/input_files/validation/AZ0156-C.json
+++ b/pipelines/short-read-alignment-and-genotyping-vector/gcp/input_files/validation/AZ0156-C.json
@@ -14,17 +14,6 @@
     "ref_pac": "gs://malariagen/references/Anopheles-gambiae-PEST_CHROMOSOMES_AgamP4/Anopheles-gambiae-PEST_CHROMOSOMES_AgamP4.fa.pac"
   },
   "ShortReadAlignmentAndGenotyping.runTimeSettings": {
-    "preemptible_tries": 0,
-    "gatk_docker": "broadinstitute/gatk3:3.7-0",
-    "picard_docker": "us.gcr.io/broad-gotc-prod/malariagen/picard:2.9.2",
-    "bwa_docker": "us.gcr.io/broad-gotc-prod/malariagen/bwa:0.7.15",
-    "biobambam_docker": "us.gcr.io/broad-gotc-prod/malariagen/biobambam2:2.0.73",
-    "samtools_docker": "us.gcr.io/broad-gotc-prod/malariagen/samtools:1.4.1",
-    "bcftools_docker": "us.gcr.io/broad-gotc-prod/malariagen/bcftools:1.11",
-    "vcftozarr_docker": "us.gcr.io/broad-gotc-prod/malariagen/samplevcftozarr:1.1",
-    "lftp_docker": "us.gcr.io/broad-gotc-prod/malariagen/lftp:1.0",
-    "select_variants_docker": "us.gcr.io/broad-gotc-prod/malariagen/sampleselectvariants:1.0",
-    "whatshap_docker": "us.gcr.io/broad-gotc-prod/malariagen/whatshap:1.0",
-    "shapeit4_docker": "us.gcr.io/broad-gotc-prod/malariagen/shapeit4:4.1.3"
+    "preemptible_tries": 0
   }
 }

--- a/pipelines/short-read-alignment-and-genotyping-vector/gcp/input_files/validation/BL0358-C.json
+++ b/pipelines/short-read-alignment-and-genotyping-vector/gcp/input_files/validation/BL0358-C.json
@@ -14,17 +14,6 @@
     "ref_pac": "gs://malariagen/references/Anopheles-gambiae-PEST_CHROMOSOMES_AgamP4/Anopheles-gambiae-PEST_CHROMOSOMES_AgamP4.fa.pac"
   },
   "ShortReadAlignmentAndGenotyping.runTimeSettings": {
-    "preemptible_tries": 0,
-    "gatk_docker": "broadinstitute/gatk3:3.7-0",
-    "picard_docker": "us.gcr.io/broad-gotc-prod/malariagen/picard:2.9.2",
-    "bwa_docker": "us.gcr.io/broad-gotc-prod/malariagen/bwa:0.7.15",
-    "biobambam_docker": "us.gcr.io/broad-gotc-prod/malariagen/biobambam2:2.0.73",
-    "samtools_docker": "us.gcr.io/broad-gotc-prod/malariagen/samtools:1.4.1",
-    "bcftools_docker": "us.gcr.io/broad-gotc-prod/malariagen/bcftools:1.11",
-    "vcftozarr_docker": "us.gcr.io/broad-gotc-prod/malariagen/samplevcftozarr:1.1",
-    "lftp_docker": "us.gcr.io/broad-gotc-prod/malariagen/lftp:1.0",
-    "select_variants_docker": "us.gcr.io/broad-gotc-prod/malariagen/sampleselectvariants:1.0",
-    "whatshap_docker": "us.gcr.io/broad-gotc-prod/malariagen/whatshap:1.0",
-    "shapeit4_docker": "us.gcr.io/broad-gotc-prod/malariagen/shapeit4:4.1.3"
+    "preemptible_tries": 0
   }
 }

--- a/pipelines/short-read-alignment-vector/gcp/input_files/AB0252-C.json
+++ b/pipelines/short-read-alignment-vector/gcp/input_files/AB0252-C.json
@@ -13,15 +13,6 @@
     "ref_pac": "gs://malariagen/references/Anopheles-gambiae-PEST_CHROMOSOMES_AgamP4/Anopheles-gambiae-PEST_CHROMOSOMES_AgamP4.fa.pac"
   },
   "ShortReadAlignment.runTimeSettings": {
-    "preemptible_tries": 0,
-    "gatk_docker": "broadinstitute/gatk3:3.7-0",
-    "picard_docker": "us.gcr.io/broad-gotc-prod/malariagen/picard:2.9.2",
-    "bwa_docker": "us.gcr.io/broad-gotc-prod/malariagen/bwa:0.7.15",
-    "biobambam_docker": "us.gcr.io/broad-gotc-prod/malariagen/biobambam2:2.0.73",
-    "samtools_docker": "us.gcr.io/broad-gotc-prod/malariagen/samtools:1.4.1",
-    "vcftozarr_docker": "us.gcr.io/broad-gotc-prod/malariagen/samplevcftozarr:1.1",
-    "lftp_docker": "us.gcr.io/broad-gotc-prod/malariagen/lftp:1.0",
-    "select_variants_docker": "us.gcr.io/broad-gotc-prod/malariagen/sampleselectvariants:1.0",
-    "whatshap_docker": "us.gcr.io/broad-gotc-prod/malariagen/whatshap:1.0"
+    "preemptible_tries": 0
   }
 }

--- a/pipelines/short-read-alignment-vector/gcp/input_files/AN0131-C.json
+++ b/pipelines/short-read-alignment-vector/gcp/input_files/AN0131-C.json
@@ -13,15 +13,6 @@
     "ref_pac": "gs://malariagen/references/Anopheles-gambiae-PEST_CHROMOSOMES_AgamP4/Anopheles-gambiae-PEST_CHROMOSOMES_AgamP4.fa.pac"
   },
   "ShortReadAlignment.runTimeSettings": {
-    "preemptible_tries": 0,
-    "gatk_docker": "broadinstitute/gatk3:3.7-0",
-    "picard_docker": "us.gcr.io/broad-gotc-prod/malariagen/picard:2.9.2",
-    "bwa_docker": "us.gcr.io/broad-gotc-prod/malariagen/bwa:0.7.15",
-    "biobambam_docker": "us.gcr.io/broad-gotc-prod/malariagen/biobambam2:2.0.73",
-    "samtools_docker": "us.gcr.io/broad-gotc-prod/malariagen/samtools:1.4.1",
-    "vcftozarr_docker": "us.gcr.io/broad-gotc-prod/malariagen/samplevcftozarr:1.1",
-    "lftp_docker": "us.gcr.io/broad-gotc-prod/malariagen/lftp:1.0",
-    "select_variants_docker": "us.gcr.io/broad-gotc-prod/malariagen/sampleselectvariants:1.0",
-    "whatshap_docker": "us.gcr.io/broad-gotc-prod/malariagen/whatshap:1.0"
+    "preemptible_tries": 0
   }
 }

--- a/pipelines/short-read-alignment-vector/gcp/input_files/small/AV0079-C.json
+++ b/pipelines/short-read-alignment-vector/gcp/input_files/small/AV0079-C.json
@@ -13,15 +13,6 @@
     "ref_pac": "gs://malariagen/references/Anopheles-gambiae-PEST_CHROMOSOMES_AgamP4/Anopheles-gambiae-PEST_CHROMOSOMES_AgamP4.fa.pac"
   },
   "ShortReadAlignment.runTimeSettings": {
-    "preemptible_tries": 0,
-    "gatk_docker": "broadinstitute/gatk3:3.7-0",
-    "picard_docker": "us.gcr.io/broad-gotc-prod/malariagen/picard:2.9.2",
-    "bwa_docker": "us.gcr.io/broad-gotc-prod/malariagen/bwa:0.7.15",
-    "biobambam_docker": "us.gcr.io/broad-gotc-prod/malariagen/biobambam2:2.0.73",
-    "samtools_docker": "us.gcr.io/broad-gotc-prod/malariagen/samtools:1.4.1",
-    "vcftozarr_docker": "us.gcr.io/broad-gotc-prod/malariagen/samplevcftozarr:1.1",
-    "lftp_docker": "us.gcr.io/broad-gotc-prod/malariagen/lftp:1.0",
-    "select_variants_docker": "us.gcr.io/broad-gotc-prod/malariagen/sampleselectvariants:1.0",
-    "whatshap_docker": "us.gcr.io/broad-gotc-prod/malariagen/whatshap:1.0"
+    "preemptible_tries": 0
   }
 }

--- a/pipelines/short-read-alignment-vector/gcp/input_files/small/AV0148-C.json
+++ b/pipelines/short-read-alignment-vector/gcp/input_files/small/AV0148-C.json
@@ -13,15 +13,6 @@
     "ref_pac": "gs://malariagen/references/Anopheles-gambiae-PEST_CHROMOSOMES_AgamP4/Anopheles-gambiae-PEST_CHROMOSOMES_AgamP4.fa.pac"
   },
   "ShortReadAlignment.runTimeSettings": {
-    "preemptible_tries": 0,
-    "gatk_docker": "broadinstitute/gatk3:3.7-0",
-    "picard_docker": "us.gcr.io/broad-gotc-prod/malariagen/picard:2.9.2",
-    "bwa_docker": "us.gcr.io/broad-gotc-prod/malariagen/bwa:0.7.15",
-    "biobambam_docker": "us.gcr.io/broad-gotc-prod/malariagen/biobambam2:2.0.73",
-    "samtools_docker": "us.gcr.io/broad-gotc-prod/malariagen/samtools:1.4.1",
-    "vcftozarr_docker": "us.gcr.io/broad-gotc-prod/malariagen/samplevcftozarr:1.1",
-    "lftp_docker": "us.gcr.io/broad-gotc-prod/malariagen/lftp:1.0",
-    "select_variants_docker": "us.gcr.io/broad-gotc-prod/malariagen/sampleselectvariants:1.0",
-    "whatshap_docker": "us.gcr.io/broad-gotc-prod/malariagen/whatshap:1.0"
+    "preemptible_tries": 0
   }
 }

--- a/structs/gcp/RunTimeSettings.wdl
+++ b/structs/gcp/RunTimeSettings.wdl
@@ -2,16 +2,4 @@ version 1.0
 
 struct RunTimeSettings {
   Int preemptible_tries
-  String gatk_docker
-  String picard_docker
-  String bwa_docker
-  String biobambam_docker
-  String cohortvcftozarr_docker
-  String samtools_docker
-  String bcftools_docker
-  String vcftozarr_docker
-  String lftp_docker
-  String select_variants_docker
-  String whatshap_docker
-  String shapeit4_docker
 }

--- a/tasks/farm5/ShortReadAlignmentTasks.wdl
+++ b/tasks/farm5/ShortReadAlignmentTasks.wdl
@@ -278,7 +278,7 @@ task ReadAlignment {
   # study [DS]: obtained from raw sequenced bam, but we can make this up for testing
   # @rg ID:130508_HS22_09812_A_D1U5TACXX_4#48 LB:7206533 SM:AN0131-C CN:SC PL:ILLUMINA DS:1087-AN-HAPMAP-DONNELLY
   String full_read_group_id = select_first([read_group_id, output_sam_basename])
-  String autogen_read_group = "@RG\tID:" + full_read_group_id + "\tSM:" + sample_id + "\tCN:SC\tPL:ILLUMINA"
+  String autogen_read_group = "@RG\\tID:" + full_read_group_id + "\\tSM:" + sample_id + "\\tCN:SC\\tPL:ILLUMINA"
   String full_read_group = select_first([read_group, autogen_read_group])
 
   command {

--- a/tasks/gcp/Alignment.wdl
+++ b/tasks/gcp/Alignment.wdl
@@ -15,7 +15,8 @@ workflow Alignment {
 
   input {
     String sample_id
-    String read_group_id
+    String? read_group_id
+    String? read_group
     String input_cram
     String input_bam
     String input_fastq1
@@ -65,6 +66,7 @@ workflow Alignment {
     input:
       sample_id = sample_id,
       read_group_id = read_group_id,
+      read_group = read_group,
       fastq1 = select_first([SamToFastq.output_fastq1, input_fastq1]),
       fastq2 = select_first([SamToFastq.output_fastq2, input_fastq2]),
       output_sam_basename = output_file_basename,

--- a/tasks/gcp/ReadBackedPhasingTasks.wdl
+++ b/tasks/gcp/ReadBackedPhasingTasks.wdl
@@ -11,6 +11,8 @@ task SelectVariants {
     File phased_sites_zarr
     String output_basename
     String contig
+
+    String docker_tag = "us.gcr.io/broad-gotc-prod/malariagen/sampleselectvariants:1.0"
     RunTimeSettings runTimeSettings
   }
 
@@ -28,7 +30,7 @@ task SelectVariants {
   }
 
   runtime {
-    docker: runTimeSettings.select_variants_docker
+    docker: docker_tag
     preemptible: runTimeSettings.preemptible_tries
     cpu: "1"
     memory: "3.75 GiB"
@@ -51,6 +53,8 @@ task WhatsHapPhase {
     String? contig
     Int internal_downsampling = 15
     ReferenceSequence reference
+
+    String docker_tag = "us.gcr.io/broad-gotc-prod/malariagen/whatshap:1.0"
     RunTimeSettings runTimeSettings
   }
 
@@ -68,7 +72,7 @@ task WhatsHapPhase {
   }
 
   runtime {
-    docker: runTimeSettings.whatshap_docker
+    docker: docker_tag
     preemptible: runTimeSettings.preemptible_tries
     cpu: "2"
     memory: "30 GiB"
@@ -86,6 +90,8 @@ task WhatsHapStats {
     File phased_vcf_index
     String output_basename
     ReferenceSequence reference
+
+    String docker_tag = "us.gcr.io/broad-gotc-prod/malariagen/whatshap:1.0"
     RunTimeSettings runTimeSettings
   }
   # TODO - figure out how to make proper use of OPTIONAL reference.ref_chr_lengths
@@ -99,7 +105,7 @@ task WhatsHapStats {
   }
 
   runtime {
-    docker: runTimeSettings.whatshap_docker
+    docker: docker_tag
     preemptible: runTimeSettings.preemptible_tries
     cpu: "2"
     memory: "7.5 GiB"

--- a/tasks/gcp/SNPGenotypingTasks.wdl
+++ b/tasks/gcp/SNPGenotypingTasks.wdl
@@ -11,7 +11,7 @@ task UnifiedGenotyper {
     File alleles_vcf_index
     String output_vcf_filename
 
-    String docker = runTimeSettings.gatk_docker
+    String docker_tag = "broadinstitute/gatk3:3.7-0"
     Int preemptible_tries = runTimeSettings.preemptible_tries
     Int num_cpu = 4
     ReferenceSequence reference
@@ -56,7 +56,7 @@ task UnifiedGenotyper {
           -XA ReadPosRankSumTest
   }
   runtime {
-    docker: docker
+    docker: docker_tag
     preemptible: preemptible_tries
     cpu: num_cpu
     memory: "15 GiB"
@@ -75,7 +75,7 @@ task VcfToZarr {
     String output_zarr_file_name
     String output_log_file_name
 
-    String docker = runTimeSettings.vcftozarr_docker
+    String docker_tag = "us.gcr.io/broad-gotc-prod/malariagen/samplevcftozarr:1.1"
     Int preemptible_tries = runTimeSettings.preemptible_tries
     Int num_cpu = 1
     RunTimeSettings runTimeSettings
@@ -103,7 +103,7 @@ task VcfToZarr {
         --zip
   }
   runtime {
-    docker: docker
+    docker: docker_tag
     preemptible: preemptible_tries
     cpu: num_cpu
     memory: "7.5 GiB"

--- a/tasks/gcp/StatisticalPhasingTasks.wdl
+++ b/tasks/gcp/StatisticalPhasingTasks.wdl
@@ -8,6 +8,8 @@ task MergeVcfs {
     Array[File] phased_sample_vcfs
     Array[File] phased_sample_vcf_indices
     String project_id
+
+    String docker_tag = "us.gcr.io/broad-gotc-prod/malariagen/bcftools:1.11"
     RunTimeSettings runTimeSettings
   }
 
@@ -20,7 +22,7 @@ task MergeVcfs {
       ~{sep=' ' phased_sample_vcfs}
   }
   runtime {
-    docker: runTimeSettings.bcftools_docker
+    docker: docker_tag
     preemptible: runTimeSettings.preemptible_tries
     cpu: "1"
     memory: "3.75 GiB"
@@ -45,6 +47,8 @@ task ShapeIt4 {
     Int pbwt_depth = 4
     # TODO - how to handle refence as an option
     ReferenceSequence? reference
+
+    String docker_tag = "us.gcr.io/broad-gotc-prod/malariagen/shapeit4:4.1.3"
     RunTimeSettings runTimeSettings
   }
 
@@ -68,7 +72,7 @@ task ShapeIt4 {
   }
 
   runtime {
-    docker: runTimeSettings.shapeit4_docker
+    docker: docker_tag
     preemptible: runTimeSettings.preemptible_tries
     cpu: "4"
     memory: "15 GiB"
@@ -87,7 +91,7 @@ task CohortVcfToZarr {
     String contig
     String output_log_file_name
 
-    String docker = runTimeSettings.cohortvcftozarr_docker
+    String docker_tag = "us.gcr.io/broad-gotc-prod/malariagen/cohortvcftozarr:1.0"
     Int preemptible_tries = runTimeSettings.preemptible_tries
     Int num_cpu = 1
     RunTimeSettings runTimeSettings
@@ -111,7 +115,7 @@ task CohortVcfToZarr {
     --log ~{output_log_file_name}
   }
   runtime {
-    docker: docker
+    docker: docker_tag
     preemptible: preemptible_tries
     cpu: num_cpu
     memory: "7.5 GiB"

--- a/tasks/gcp/Tasks.wdl
+++ b/tasks/gcp/Tasks.wdl
@@ -6,6 +6,8 @@ task BgzipAndTabix {
     input {
         File input_vcf
         String output_basename
+
+        String docker_tag = "us.gcr.io/broad-gotc-prod/malariagen/bcftools:1.11"
         RunTimeSettings runTimeSettings
     }
 
@@ -19,7 +21,7 @@ task BgzipAndTabix {
         tabix ~{output_basename}.vcf.gz
     }
     runtime {
-        docker: runTimeSettings.bcftools_docker
+        docker: docker_tag
         preemptible: runTimeSettings.preemptible_tries
         cpu: "1"
         memory: "3.75 GiB"
@@ -34,6 +36,8 @@ task BgzipAndTabix {
 task Tabix {
     input {
         File input_file
+
+        String docker_tag = "us.gcr.io/broad-gotc-prod/malariagen/bcftools:1.11"
         RunTimeSettings runTimeSettings
     }
 
@@ -47,7 +51,7 @@ task Tabix {
         tabix ~{local_file}
     }
     runtime {
-        docker: runTimeSettings.bcftools_docker
+        docker: docker_tag
         preemptible: runTimeSettings.preemptible_tries
         cpu: "1"
         memory: "3.75 GiB"


### PR DESCRIPTION
Updating gcp flavor of Vector pipelines to handle updates applied to farm5.
- Have the dockers set in the tasks, not in the runtime block
- Allow alignment workflow (-> bwa) to take either read_group or read_group_id as possible parameters
- Fixed bug in setting of bwa's @RG tag for when read_group_id is supplied.
- Added task ExtractReadGroup, used in farm5 implementation of alignment outer pipeline.