### PR TITLE
Update dockerfiles

### DIFF
--- a/dockerfiles/GATK/Dockerfile
+++ b/dockerfiles/GATK/Dockerfile
@@ -1,0 +1,35 @@
+FROM broadinstitute/gatk3:3.7-0
+ARG DEBIAN_FRONTEND=noninteractive
+
+ARG HTSLIB_VERSION=1.11
+ARG HTSLIB_URL="https://github.com/samtools/htslib/archive/${HTSLIB_VERSION}.tar.gz"
+ARG HTSLIB_DIR="/opt/htslib"
+ARG BUILD_TOOLS="build-essential autoconf"
+
+# Change repositories that apt uses (to cope with Debian Jessie in base image)
+RUN echo "deb http://cdn-fastly.deb.debian.org/debian/ jessie main" > /etc/apt/sources.list && \
+    echo "deb-src http://cdn-fastly.deb.debian.org/debian/ jessie main" >> /etc/apt/sources.list && \
+    echo "deb http://security.debian.org/ jessie/updates main" >> /etc/apt/sources.list && \
+    echo "deb-src http://security.debian.org/ jessie/updates main" >> /etc/apt/sources.list && \
+    echo "deb [check-valid-until=no] http://archive.debian.org/debian jessie-backports main" > /etc/apt/sources.list.d/jessie-backports.list && \
+    echo "deb-src [check-valid-until=no] http://archive.debian.org/debian jessie-backports main" >> /etc/apt/sources.list.d/jessie-backports.list 
+
+# Install dependencies
+RUN apt-get update -o Acquire::Check-Valid-Until=false -qq -y && \
+    apt-get install -y ${BUILD_TOOLS} \
+                       libcurl4-openssl-dev libssl-dev
+
+# Install htslib
+RUN mkdir -p ${HTSLIB_DIR} && \
+    cd ${HTSLIB_DIR} && \
+    curl -fsSL ${HTSLIB_URL} | tar xzf - --strip-components=1 && \
+    autoheader && \
+    autoconf && \
+    ./configure && \
+    make && \
+    make install
+
+# Clean up
+RUN apt-get remove -y ${BUILD_TOOLS} && \ 
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*

--- a/dockerfiles/README.md
+++ b/dockerfiles/README.md
@@ -29,6 +29,8 @@ The Broad Institute provided Dockerfile for GATK can be found on [docker hub](ht
 - For GATK 3.X use https://hub.docker.com/r/broadinstitute/gatk3
 - For GATK 4.X use https://hub.docker.com/r/broadinstitute/gatk
 
+The GATK 3.7-0 image (provided by the Broad Institute) has been been extended with htslib software for use in Sanger pipelines.
+
 ### Lftp
 Contains the lftp too, a simple ftp client, used for downloading files from ena
 
@@ -57,7 +59,7 @@ A farm5-specific docker image, providing dependencies for the iRODS import and b
 - samtools 1.4.1 (htslib 1.4.1) - `docker build . --tag=samtools:1.4.1 --build-arg version=1.4.1`
 - picard 2.9.2 - ` docker build . --tag=picard:2.9.2 --build-arg version=2.9.2`
 - biobambam 2.0.73 - `docker build . --tag=biobambam:2.0.73`
-- GATK 3.7-0 - `docker pull broadinstitute/gatk3:3.7-0`
+- GATK 3.7-0 - `docker build . --tag=sangerpathogens/gatk3:3.7.0`
 - lftp - `docker build . --tag=lftp:1.0`
 - cohortvcftozarr - `docker build . --tag=cohortvcftozarr:1.0`
 - samplevcftozarr - `docker build . --tag=samplevcftozarr:1.0`

--- a/dockerfiles/SampleVcfToZarr/Dockerfile
+++ b/dockerfiles/SampleVcfToZarr/Dockerfile
@@ -1,15 +1,42 @@
 FROM python:3.7.2
+ARG DEBIAN_FRONTEND=noninteractive
 
-RUN pip install --upgrade pip
+ARG HTSLIB_VERSION=1.11
+ARG HTSLIB_URL="https://github.com/samtools/htslib/archive/${HTSLIB_VERSION}.tar.gz"
+ARG HTSLIB_DIR="/opt/htslib"
+ARG BUILD_TOOLS="build-essential autoconf"
 
-COPY requirements.txt .
-RUN pip3 install scikit-allel==1.3.1
-RUN pip3 install zarr==2.4.0
+# Install htslib dependencies
+RUN apt-get update -qq -y && \
+    apt-get purge -y libssl-dev && \
+    apt-get install -y ${BUILD_TOOLS} \
+                       libssl1.0-dev \
+                       curl libcurl4-openssl-dev
 
+# Install htslib
+RUN mkdir -p ${HTSLIB_DIR} && \
+    cd ${HTSLIB_DIR} && \
+    curl -fsSL ${HTSLIB_URL} | tar xzf - --strip-components=1 && \
+    autoheader && \
+    autoconf && \
+    ./configure && \
+    make && \
+    make install
+
+# Clean up
+RUN apt-get remove -y ${BUILD_TOOLS} && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# Install sample_vcf_to_zarr.py dependencies
+# Note that numpy is installed separately to avoid a wheel build failure for scikit-allel
+RUN pip install --upgrade pip \
+ && pip3 install numpy \
+ && pip3 install \
+      scikit-allel==1.3.1 \
+      zarr==2.4.0
+
+# Copy sample_vcf_to_zarr.py to WORKDIR
 RUN mkdir /tools
 WORKDIR /tools
-
-COPY sample_vcf_to_zarr.py .
-COPY test_sample_vcf_to_zarr.py .
-COPY fixture ./fixture
-
+COPY . .


### PR DESCRIPTION
- Update SampleVcfToZarr dockerfile to include htslib
- Create GATK dockerfile (by extending broadinstitute/gatk3:3.7-0 image with htslib).
- Update dockerfiles README