### PR TITLE
Add zones to task runtime for Phasing pipeline

### DIFF
--- a/pipelines/phasing-vector/gcp/Phasing.wdl
+++ b/pipelines/phasing-vector/gcp/Phasing.wdl
@@ -33,6 +33,7 @@ workflow Phasing {
 
     ReferenceSequence reference
     RunTimeSettings runTimeSettings
+    String runtime_zones
   }
 
   # TODO: extract sample_id, sample_bam, and sample_vcf information from the maifest file (or inputs)
@@ -65,7 +66,8 @@ workflow Phasing {
           phased_sites_zarr = phased_sites_zarr,
           contig = chromosome,
           reference = reference,
-          runTimeSettings = runTimeSettings
+          runTimeSettings = runTimeSettings,
+          runtime_zones = runtime_zones
       }
     }
 
@@ -81,7 +83,8 @@ workflow Phasing {
         haplotype_reference_panel = if defined(haplotype_reference_panels) then select_first([haplotype_reference_panels])[chr_idx] else none,
         haplotype_reference_panel_index = if defined(haplotype_reference_panel_indices) then select_first([haplotype_reference_panel_indices])[chr_idx] else none,
         interval_list = interval_list,
-        runTimeSettings = runTimeSettings
+        runTimeSettings = runTimeSettings,
+        runtime_zones = runtime_zones
     }
   }
 

--- a/pipelines/phasing-vector/gcp/ReadBackedPhasing.wdl
+++ b/pipelines/phasing-vector/gcp/ReadBackedPhasing.wdl
@@ -29,6 +29,7 @@ workflow ReadBackedPhasing {
 
     ReferenceSequence reference
     RunTimeSettings runTimeSettings
+    String runtime_zones
   }
 
   if (!defined(sample_zarr)) {
@@ -39,7 +40,8 @@ workflow ReadBackedPhasing {
         sample_id = sample_id,
         output_zarr_file_name = output_basename + ".zarr",
         output_log_file_name = output_basename + ".log",
-        runTimeSettings = runTimeSettings
+        runTimeSettings = runTimeSettings,
+        runtime_zones = runtime_zones
     }
   }
 
@@ -51,14 +53,16 @@ workflow ReadBackedPhasing {
       phased_sites_zarr = phased_sites_zarr,
       output_basename = output_basename,
       contig = contig,
-      runTimeSettings = runTimeSettings
+      runTimeSettings = runTimeSettings,
+      runtime_zones = runtime_zones
   }
   # bgzip and index the phased_vcf (Needed by WhatsHap phase)
   call Tasks.BgzipAndTabix as BgzipAndTabixSelectVariantsVcf {
     input:
       input_vcf = SelectVariants.subset_vcf,
       output_basename = output_basename + ".subset",
-      runTimeSettings = runTimeSettings
+      runTimeSettings = runTimeSettings,
+      runtime_zones = runtime_zones
   }
 
   # If the bam index is not provided, generate it.
@@ -66,7 +70,8 @@ workflow ReadBackedPhasing {
     call ShortReadAlignmentTasks.SamtoolsIndex {
       input:
         input_file = input_bam,
-        runTimeSettings = runTimeSettings
+        runTimeSettings = runTimeSettings,
+        runtime_zones = runtime_zones
     }
   }
 
@@ -79,13 +84,15 @@ workflow ReadBackedPhasing {
       subset_vcf_index = BgzipAndTabixSelectVariantsVcf.vcf_index,
       output_filename = output_basename + ".phased.vcf.gz",
       reference = reference,
-      runTimeSettings = runTimeSettings
+      runTimeSettings = runTimeSettings,
+      runtime_zones = runtime_zones
   }
   # index the phased_vcf (needed for bcftools merge in statistical phasing pipeline)
   call Tasks.Tabix as TabixPhasedVcf {
     input:
       input_file = WhatsHapPhase.phased_vcf,
-      runTimeSettings = runTimeSettings
+      runTimeSettings = runTimeSettings,
+      runtime_zones = runtime_zones
   }
   # Step 3: WhatsHap stats
   call ReadBackedPhasingTasks.WhatsHapStats {
@@ -94,7 +101,8 @@ workflow ReadBackedPhasing {
       phased_vcf_index = TabixPhasedVcf.output_index_file,
       output_basename = output_basename,
       reference = reference,
-      runTimeSettings = runTimeSettings
+      runTimeSettings = runTimeSettings,
+      runtime_zones = runtime_zones
   }
 
   output {

--- a/pipelines/phasing-vector/gcp/StatisticalPhasing.wdl
+++ b/pipelines/phasing-vector/gcp/StatisticalPhasing.wdl
@@ -25,6 +25,7 @@ workflow StatisticalPhasing {
     File? haplotype_reference_panel_index
 
     RunTimeSettings runTimeSettings
+    String runtime_zones
   }
 
   # Step 1: Merge VCFs
@@ -33,7 +34,8 @@ workflow StatisticalPhasing {
       phased_sample_vcfs = phased_sample_vcfs,
       phased_sample_vcf_indices = phased_sample_vcf_indices,
       project_id = project_id,
-      runTimeSettings = runTimeSettings
+      runTimeSettings = runTimeSettings,
+      runtime_zones = runtime_zones
   }
 
   # Step 2: bgzip the merged VCF
@@ -41,7 +43,8 @@ workflow StatisticalPhasing {
     input:
       input_vcf = MergeVcfs.merged_vcf,
       output_basename = project_id + "_merged",
-      runTimeSettings = runTimeSettings
+      runTimeSettings = runTimeSettings,
+      runtime_zones = runtime_zones
   }
 
   # Step 3: ShapeIt4
@@ -55,12 +58,14 @@ workflow StatisticalPhasing {
         genetic_map = genetic_map,
         haplotype_reference_panel = haplotype_reference_panel,
         haplotype_reference_panel_index = haplotype_reference_panel_index,
-        runTimeSettings = runTimeSettings
+        runTimeSettings = runTimeSettings,
+        runtime_zones = runtime_zones
     }
     call Tasks.Tabix as Tabix {
       input:
         input_file = ShapeIt4.region_phased_vcf,
-        runTimeSettings = runTimeSettings
+        runTimeSettings = runTimeSettings,
+        runtime_zones = runtime_zones
     }
   }
 
@@ -71,7 +76,8 @@ workflow StatisticalPhasing {
       region_phased_vcfs_indices = Tabix.output_index_file,
       interval_list = interval_list,
       project_id = project_id,
-      runTimeSettings = runTimeSettings
+      runTimeSettings = runTimeSettings,
+      runtime_zones = runtime_zones
   }
 
   # Step 5: Cohort VCF to Zarr
@@ -81,7 +87,8 @@ workflow StatisticalPhasing {
       contig = contig,
       output_zarr_file_name = project_id + ".zarr",
       output_log_file_name = project_id + ".log",
-      runTimeSettings = runTimeSettings
+      runTimeSettings = runTimeSettings,
+      runtime_zones = runtime_zones
   }
 
   meta {

--- a/tasks/gcp/ReadBackedPhasingTasks.wdl
+++ b/tasks/gcp/ReadBackedPhasingTasks.wdl
@@ -16,6 +16,7 @@ task SelectVariants {
     Int preemptible_tries = runTimeSettings.preemptible_tries
     Int num_cpu = 1
     RunTimeSettings runTimeSettings
+    String runtime_zones
   }
 
   Int mem_size = ceil(size(sample_zarr, "GiB") * 3)
@@ -37,6 +38,7 @@ task SelectVariants {
     cpu: num_cpu
     memory: "3.75 GiB"
     disks: "local-disk " + disk_size + " HDD"
+    zones: runtime_zones
   }
 
   output {
@@ -60,6 +62,7 @@ task WhatsHapPhase {
     Int preemptible_tries = runTimeSettings.preemptible_tries
     Int num_cpu = 2
     RunTimeSettings runTimeSettings
+    String runtime_zones
   }
 
   Int disk_size = ceil(size(subset_vcf, "GiB") + size(subset_vcf_index, "GiB") + size(input_bam, "GiB") + size(input_bam_index, "GiB")) * 5 + 20
@@ -81,6 +84,7 @@ task WhatsHapPhase {
     cpu: num_cpu
     memory: "50 GiB"
     disks: "local-disk " + disk_size + " HDD"
+    zones: runtime_zones
   }
 
   output {
@@ -99,6 +103,7 @@ task WhatsHapStats {
     Int preemptible_tries = runTimeSettings.preemptible_tries
     Int num_cpu = 2
     RunTimeSettings runTimeSettings
+    String runtime_zones
   }
   # TODO - figure out how to make proper use of OPTIONAL reference.ref_chr_lengths
   command {
@@ -115,6 +120,7 @@ task WhatsHapStats {
     preemptible: preemptible_tries
     cpu: num_cpu
     memory: "7.5 GiB"
+    zones: runtime_zones
   }
 
   output {

--- a/tasks/gcp/SNPGenotypingTasks.wdl
+++ b/tasks/gcp/SNPGenotypingTasks.wdl
@@ -82,6 +82,7 @@ task VcfToZarr {
     Int preemptible_tries = runTimeSettings.preemptible_tries
     Int num_cpu = 1
     RunTimeSettings runTimeSettings
+    String runtime_zones = "us-central1-b"
   }
 
   Int disk_size = (ceil(size(input_vcf, "GiB")) * 4) + 20
@@ -114,6 +115,7 @@ task VcfToZarr {
     cpu: num_cpu
     memory: "7.5 GiB"
     disks: "local-disk " + disk_size + " HDD"
+    zones: runtime_zones
   }
   output {
     File output_log_file = output_log_file_name

--- a/tasks/gcp/ShortReadAlignmentTasks.wdl
+++ b/tasks/gcp/ShortReadAlignmentTasks.wdl
@@ -735,6 +735,7 @@ task SamtoolsIndex {
     Int preemptible_tries = runTimeSettings.preemptible_tries
     Int num_cpu = 2
     RunTimeSettings runTimeSettings
+    String runtime_zones = "us-central1-b"
   }
 
   Int disk_size = ceil(3 * size(input_file, "GiB")) + 20
@@ -759,6 +760,7 @@ task SamtoolsIndex {
     cpu: num_cpu
     memory: "3.75 GiB"
     disks: "local-disk " + disk_size + " HDD"
+    zones: runtime_zones
   }
 
   output {

--- a/tasks/gcp/StatisticalPhasingTasks.wdl
+++ b/tasks/gcp/StatisticalPhasingTasks.wdl
@@ -14,6 +14,7 @@ task MergeVcfs {
     Int num_cpu = 1
     Float mem_gb = 3.75
     RunTimeSettings runTimeSettings
+    String runtime_zones
   }
 
   Int disk_size = ceil(size(phased_sample_vcfs, "GiB") + size(phased_sample_vcf_indices, "GiB")) * 10 + 20
@@ -30,6 +31,7 @@ task MergeVcfs {
     cpu: num_cpu
     memory: mem_gb + " GiB"
     disks: "local-disk " + disk_size + " HDD"
+    zones: runtime_zones
   }
   output {
     File merged_vcf = "~{project_id}_merged.vcf"
@@ -57,6 +59,7 @@ task ShapeIt4 {
     Int num_cpu = 4
     Float mem_gb = 15
     RunTimeSettings runTimeSettings
+    String runtime_zones
   }
 
   Int disk_size = ceil(size(merged_vcf, "GiB") + size(merged_vcf_index, "GiB") + size(genetic_map, "GiB")) * 5 + 20
@@ -87,6 +90,7 @@ task ShapeIt4 {
     cpu: num_cpu
     memory: mem_gb + " GiB"
     disks: "local-disk " + disk_size + " HDD"
+    zones: runtime_zones
   }
 
   output {
@@ -109,6 +113,7 @@ task LigateRegions {
     Int num_cpu = 1
     Float mem_gb = 15
     RunTimeSettings runTimeSettings
+    String runtime_zones
   }
 
   Int disk_size = ceil((size(region_phased_vcfs, "GiB") + size(region_phased_vcfs, "GiB")) * 20) + 20
@@ -152,6 +157,7 @@ task LigateRegions {
     cpu: num_cpu
     memory: mem_gb + " GiB"
     disks: "local-disk " + disk_size + " HDD"
+    zones: runtime_zones
   }
 
   output {
@@ -173,6 +179,7 @@ task CohortVcfToZarr {
     Int num_cpu = 1
     Float mem_gb = 7.5
     RunTimeSettings runTimeSettings
+    String runtime_zones
   }
 
   Int disk_size = (ceil(size(input_vcf, "GiB")) * 4) + 20
@@ -199,6 +206,7 @@ task CohortVcfToZarr {
     cpu: num_cpu
     memory: mem_gb + " GiB"
     disks: "local-disk " + disk_size + " HDD"
+    zones: runtime_zones
   }
   output {
     File output_log_file = output_log_file_name

--- a/tasks/gcp/Tasks.wdl
+++ b/tasks/gcp/Tasks.wdl
@@ -11,6 +11,7 @@ task BgzipAndTabix {
     Int preemptible_tries = runTimeSettings.preemptible_tries
     Int num_cpu = 1
     RunTimeSettings runTimeSettings
+    String runtime_zones = "us-central1-b"
   }
 
   Int disk_size = ceil(size(input_vcf, "GiB")) * 3 + 20
@@ -28,6 +29,7 @@ task BgzipAndTabix {
     cpu: num_cpu
     memory: "3.75 GiB"
     disks: "local-disk " + disk_size + " HDD"
+    zones: runtime_zones
   }
   output {
     File vcf = "~{output_basename}.vcf.gz"
@@ -43,6 +45,7 @@ task Tabix {
     Int preemptible_tries = runTimeSettings.preemptible_tries
     Int num_cpu = 1
     RunTimeSettings runTimeSettings
+    String runtime_zones = "us-central1-b"
   }
 
   Int disk_size = ceil(size(input_file, "GiB")) * 2 + 20
@@ -60,6 +63,7 @@ task Tabix {
     cpu: num_cpu
     memory: "3.75 GiB"
     disks: "local-disk " + disk_size + " HDD"
+    zones: runtime_zones
   }
   output {
     # output the path to the copied local file AND the created index so they are side by side.


### PR DESCRIPTION
Add runtime zones as a required input for all phasing tasks. For shared tasks used by phasing, there is a default value "us-central1-b" which is the default value used by cromwell (see documentation [here](https://cromwell.readthedocs.io/en/stable/RuntimeAttributes/#zones))