### PR TITLE
Add disk size to ShapeIt4 when using a reference panel

### DIFF
--- a/tasks/gcp/StatisticalPhasingTasks.wdl
+++ b/tasks/gcp/StatisticalPhasingTasks.wdl
@@ -63,7 +63,7 @@ task ShapeIt4 {
   }
 
   Int disk_size = (ceil(size(merged_vcf, "GiB") + size(merged_vcf_index, "GiB") + size(genetic_map, "GiB")) * 5) + 20
-  Int total_disk_size = if defined(haplotype_reference_panel) then (ceil(size(merged_vcf, "GiB")) * 5) + disk_size else disk_size
+  Int total_disk_size = if defined(haplotype_reference_panel) then (ceil(size(haplotype_reference_panel, "GiB")) * 5) + disk_size else disk_size
   String output_prefix = sub(region, ":", "_")
   String output_filename = output_prefix + "_" +  project_id + "_phased.vcf.gz"
 

--- a/tasks/gcp/StatisticalPhasingTasks.wdl
+++ b/tasks/gcp/StatisticalPhasingTasks.wdl
@@ -62,12 +62,12 @@ task ShapeIt4 {
     String runtime_zones
   }
 
-  Int disk_size = ceil(size(merged_vcf, "GiB") + size(merged_vcf_index, "GiB") + size(genetic_map, "GiB")) * 5 + 20
+  Int disk_size = (ceil(size(merged_vcf, "GiB") + size(merged_vcf_index, "GiB") + size(genetic_map, "GiB")) * 5) + 20
+  Int total_disk_size = if defined(haplotype_reference_panel) then (ceil(size(merged_vcf, "GiB")) * 5) + disk_size else disk_size
   String output_prefix = sub(region, ":", "_")
   String output_filename = output_prefix + "_" +  project_id + "_phased.vcf.gz"
 
   command {
-    #TODO - handle reference...
     touch ~{merged_vcf_index}
     shapeit4 \
         --input ~{merged_vcf} \
@@ -89,7 +89,7 @@ task ShapeIt4 {
     preemptible: preemptible_tries
     cpu: num_cpu
     memory: mem_gb + " GiB"
-    disks: "local-disk " + disk_size + " HDD"
+    disks: "local-disk " + total_disk_size + " HDD"
     zones: runtime_zones
   }
 


### PR DESCRIPTION
The [small test run](https://app.terra.bio/#workspaces/warp-pipelines/MalariaGEN_vector_phasing_Ag3-2_broad_test/job_history) revealed an issue where insufficient disk was requested in order to load the reference panel (resulting in an out of space error). This would likely only be an issue on small sample sets, but this PR should address the issue for any size sample set. 