### PR TITLE
Optimise GCP VcfToZarr and generalise to handle other vector species with different contigs

### DIFF
--- a/dockerfiles/SampleVcfToZarr/Dockerfile
+++ b/dockerfiles/SampleVcfToZarr/Dockerfile
@@ -1,40 +1,14 @@
-FROM python:3.7.2
+FROM python:3.8-slim-bullseye
 ARG DEBIAN_FRONTEND=noninteractive
 
-ARG HTSLIB_VERSION=1.11
-ARG HTSLIB_URL="https://github.com/samtools/htslib/archive/${HTSLIB_VERSION}.tar.gz"
-ARG HTSLIB_DIR="/opt/htslib"
-ARG BUILD_TOOLS="build-essential autoconf"
-
-# Install htslib dependencies
+# Install OS dependencies
 RUN apt-get update -qq -y && \
-    apt-get purge -y libssl-dev && \
-    apt-get install -y ${BUILD_TOOLS} \
-                       libssl1.0-dev \
-                       curl libcurl4-openssl-dev
+    apt-get install -y tabix
 
-# Install htslib
-RUN mkdir -p ${HTSLIB_DIR} && \
-    cd ${HTSLIB_DIR} && \
-    curl -fsSL ${HTSLIB_URL} | tar xzf - --strip-components=1 && \
-    autoheader && \
-    autoconf && \
-    ./configure && \
-    make && \
-    make install
-
-# Clean up
-RUN apt-get remove -y ${BUILD_TOOLS} && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
-
-# Install sample_vcf_to_zarr.py dependencies
-# Note that numpy is installed separately to avoid a wheel build failure for scikit-allel
-RUN pip install --upgrade pip \
- && pip3 install numpy \
- && pip3 install \
-      scikit-allel==1.3.1 \
-      zarr==2.4.0
+# Install Python dependencies
+RUN pip3 install --upgrade pip
+COPY requirements.txt .
+RUN pip3 install -r requirements.txt
 
 # Copy sample_vcf_to_zarr.py to WORKDIR
 RUN mkdir /tools

--- a/dockerfiles/SampleVcfToZarr/requirements.txt
+++ b/dockerfiles/SampleVcfToZarr/requirements.txt
@@ -1,2 +1,2 @@
-scikit-allel==1.3.1
-zarr==2.4.0
+scikit-allel==1.3.5
+zarr==2.11.3

--- a/dockerfiles/SampleVcfToZarr/sample_vcf_to_zarr.py
+++ b/dockerfiles/SampleVcfToZarr/sample_vcf_to_zarr.py
@@ -135,6 +135,8 @@ def main():
         log_file_needs_closing = True
     
     if not contigs:
+        print("No contig parameters, discovering from VCF headers", file=log_file)
+
         if input_vcf_path.endswith((".gz", ".bgz")):
             vcf_opener = gzip.open
         else:
@@ -150,6 +152,8 @@ def main():
                 else:
                     # Header is finished, no need to read the rest
                     break
+
+        print(f"Discovered contigs: {contigs}", file=log_file)
                
     try:
         if not contigs:
@@ -162,6 +166,7 @@ def main():
             sys.exit(1)
             
         for contig in contigs:
+            print(f"Processing contig {contig}...", file=log_file)
 
             allel.vcf_to_zarr(
                 input=input_vcf_path,

--- a/pipelines/SNP-genotyping-vector/gcp/SNPGenotyping.wdl
+++ b/pipelines/SNP-genotyping-vector/gcp/SNPGenotyping.wdl
@@ -13,7 +13,7 @@ import "../../../structs/ReferenceSequence.wdl"
 import "../../../tasks/gcp/SNPGenotypingTasks.wdl" as Tasks
 
 workflow SNPGenotyping {
-  String pipeline_version = "1.0.0"
+  String pipeline_version = "1.0.1"
 
   input {
     String sample_id
@@ -41,6 +41,7 @@ workflow SNPGenotyping {
   call Tasks.VcfToZarr {
     input:
       input_vcf = UnifiedGenotyper.output_vcf,
+      input_vcf_index = UnifiedGenotyper.output_vcf_index,
       sample_id = sample_id,
       output_zarr_file_name = output_basename + ".zarr",
       output_log_file_name = output_basename + ".log",

--- a/pipelines/phasing-vector/gcp/Phasing.wdl
+++ b/pipelines/phasing-vector/gcp/Phasing.wdl
@@ -22,6 +22,7 @@ workflow Phasing {
     Array[File] input_bam_indices
     Array[File] sample_zarrs
     Array[File] sample_vcfs = []
+    Array[File] sample_vcf_indices = []
     File called_sites_zarr
     File phased_sites_zarr
     Array[String] chromosome_list
@@ -62,6 +63,7 @@ workflow Phasing {
           input_bam_index = input_bam_indices[idx],
           sample_zarr = sample_zarrs[idx],
 #         sample_vcf = sample_vcfs[idx],
+#         sample_vcf_index = sample_vcf_indices[idx],
           called_sites_zarr = called_sites_zarr,
           phased_sites_zarr = phased_sites_zarr,
           contig = chromosome,

--- a/pipelines/phasing-vector/gcp/ReadBackedPhasing.wdl
+++ b/pipelines/phasing-vector/gcp/ReadBackedPhasing.wdl
@@ -23,6 +23,7 @@ workflow ReadBackedPhasing {
     File? input_bam_index
     File? sample_zarr
     File? sample_vcf
+    File? sample_vcf_index
     File called_sites_zarr
     File phased_sites_zarr
     String contig
@@ -37,6 +38,7 @@ workflow ReadBackedPhasing {
     call SNPGenotypingTasks.VcfToZarr {
       input:
         input_vcf = select_first([sample_vcf]),
+        input_vcf_index = select_first([sample_vcf_index]),
         sample_id = sample_id,
         output_zarr_file_name = output_basename + ".zarr",
         output_log_file_name = output_basename + ".log",

--- a/tasks/gcp/SNPGenotypingTasks.wdl
+++ b/tasks/gcp/SNPGenotypingTasks.wdl
@@ -79,7 +79,7 @@ task VcfToZarr {
     String output_zarr_file_name
     String output_log_file_name
 
-    String docker_tag = "us.gcr.io/broad-gotc-prod/malariagen/samplevcftozarr:1.2"
+    String docker_tag = "gcr.io/malariagen-jupyterhub/malariagen-pipelines/samplevcftozarr:1.3"
     Int preemptible_tries = runTimeSettings.preemptible_tries
     Int num_cpu = 1
     RunTimeSettings runTimeSettings

--- a/tasks/gcp/SNPGenotypingTasks.wdl
+++ b/tasks/gcp/SNPGenotypingTasks.wdl
@@ -74,6 +74,7 @@ task UnifiedGenotyper {
 task VcfToZarr {
   input {
     File input_vcf
+    File input_vcf_index
     String sample_id
     String output_zarr_file_name
     String output_log_file_name
@@ -88,10 +89,8 @@ task VcfToZarr {
   Int disk_size = (ceil(size(input_vcf, "GiB")) * 4) + 20
 
   command {
-    vcf_file_name="~{sample_id}.vcf"
-    bgzip -d -c ~{input_vcf} > $vcf_file_name
     python /tools/sample_vcf_to_zarr.py \
-        --input $vcf_file_name \
+        --input ~{input_vcf} \
         --output ~{output_zarr_file_name} \
         --sample ~{sample_id} \
         --field variants/MQ \
@@ -122,4 +121,3 @@ task VcfToZarr {
     File zarr_output = "~{output_zarr_file_name}.zip"
   }
 }
-

--- a/tasks/gcp/SNPGenotypingTasks.wdl
+++ b/tasks/gcp/SNPGenotypingTasks.wdl
@@ -79,7 +79,7 @@ task VcfToZarr {
     String output_zarr_file_name
     String output_log_file_name
 
-    String docker_tag = "gcr.io/malariagen-jupyterhub/malariagen-pipelines/samplevcftozarr:1.3"
+    String docker_tag = "gcr.io/malariagen-jupyterhub/malariagen-pipelines/samplevcftozarr:1.4"
     Int preemptible_tries = runTimeSettings.preemptible_tries
     Int num_cpu = 1
     RunTimeSettings runTimeSettings
@@ -88,6 +88,9 @@ task VcfToZarr {
 
   Int disk_size = (ceil(size(input_vcf, "GiB")) * 4) + 20
 
+  # The --tabix "tabix -h" parameter shouldn't be needed, as scikit-allel
+  # should internally be adding that parameter to ensure the header rows
+  # are included, but for some reason it's not working.
   command {
     python /tools/sample_vcf_to_zarr.py \
         --input ~{input_vcf} \
@@ -97,6 +100,7 @@ task VcfToZarr {
         --field calldata/GT \
         --field calldata/GQ \
         --field calldata/AD \
+        --tabix "tabix -h" \
         --log ~{output_log_file_name} \
         --zip
     rm $vcf_file_name

--- a/tasks/gcp/SNPGenotypingTasks.wdl
+++ b/tasks/gcp/SNPGenotypingTasks.wdl
@@ -97,13 +97,6 @@ task VcfToZarr {
         --field calldata/GT \
         --field calldata/GQ \
         --field calldata/AD \
-        --contig 2R \
-        --contig 2L \
-        --contig 3R \
-        --contig 3L \
-        --contig X \
-        --contig Y_unplaced \
-        --contig UNKN \
         --log ~{output_log_file_name} \
         --zip
     rm $vcf_file_name

--- a/tasks/gcp/SNPGenotypingTasks.wdl
+++ b/tasks/gcp/SNPGenotypingTasks.wdl
@@ -88,10 +88,11 @@ task VcfToZarr {
 
   Int disk_size = (ceil(size(input_vcf, "GiB")) * 4) + 20
 
-  # The --tabix "tabix -h" parameter shouldn't be needed, as scikit-allel
-  # should internally be adding that parameter to ensure the header rows
-  # are included, but for some reason it's not working.
+  # Currently scikit-allel has a bug where parsing breaks if the index file is
+  # older than the VCF file. We work around that here by touching the index file.
+
   command {
+    touch ~{input_vcf_index}
     python /tools/sample_vcf_to_zarr.py \
         --input ~{input_vcf} \
         --output ~{output_zarr_file_name} \
@@ -100,10 +101,8 @@ task VcfToZarr {
         --field calldata/GT \
         --field calldata/GQ \
         --field calldata/AD \
-        --tabix "tabix -h" \
         --log ~{output_log_file_name} \
         --zip
-    rm $vcf_file_name
   }
   runtime {
     docker: docker_tag


### PR DESCRIPTION
Running the SNP genotyping pipeline on Terra I noticed that the VcfToZarr task is taking much longer than expected.

Looking at the logs, some contigs are taking a long time to parse the first chunk. This would be expected if no index file is being used, so all previous rows have to be scanned to find the first row for a given contig.

This PR modifies the VcfToZarr task to include the VCF index file as an input, and to use the bgzipped VCF file.

Also the contig options were previously hard-coded, which only works for An. gambiae. I removed the contig parameters from the VcfToZarr task, which means contigs should be discovered from the input VCF.