### PR TITLE
Add max retries runtime attribute

### DIFF
--- a/tasks/gcp/StatisticalPhasingTasks.wdl
+++ b/tasks/gcp/StatisticalPhasingTasks.wdl
@@ -58,6 +58,7 @@ task ShapeIt4 {
     Int preemptible_tries = 2
     Int num_cpu = 4
     Float mem_gb = 15
+    Int max_retries = 3
     RunTimeSettings runTimeSettings
     String runtime_zones
   }
@@ -89,6 +90,7 @@ task ShapeIt4 {
     preemptible: preemptible_tries
     cpu: num_cpu
     memory: mem_gb + " GiB"
+    maxRetries: max_retries
     disks: "local-disk " + total_disk_size + " HDD"
     zones: runtime_zones
   }


### PR DESCRIPTION
During the haplotype phasing run for Ag3.9 we have encountered some issues during the statistical phasing where multiple shards have failed due to out of memory errors. 

To avoid restarting the whole run (which re-computes all shards for the ShapeIt4 task even when they completed previously), we want to enable the use of the Retry with More Memory feature on this task, which requires specifying a max number of retries. 